### PR TITLE
change default directory for saving files

### DIFF
--- a/src/gui/my_controls.cpp
+++ b/src/gui/my_controls.cpp
@@ -983,6 +983,8 @@ ProperOverwriteCheckSaveDialog::ProperOverwriteCheckSaveDialog(wxWindow *parent,
 :
 wxFileDialog(parent, message, wxEmptyString, wxEmptyString, wildcard, wxFD_SAVE, wxDefaultPosition, wxDefaultSize, wxFileDialogNameStr)
 {
+	wxString default_dir = main_frame->current_project.database.database_file.GetPath();
+	wxFileDialog::SetDirectory(default_dir);
 
 	extension_lowercase = wanted_extension.Lower();
 	extension_uppercase = wanted_extension.Upper();


### PR DESCRIPTION
This makes the default location for saving files from ProperOverwriteCheckSaveDialog the directory of the database. This attempts to solve #250 but also changes the default location for other events such as exporting refinement packages or saving angular distributions. 