### PR TITLE
enable openmp using cmake

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
         "BUILD_OpenMP":true,
     },
     //"cmake.configureEnvironment": {
-    //    "WX_CONFIG":"/Users/rohoua/work/software/wx/bin/wx-config",
+    //    "WX_CONFIG":"/path/to/your/wx/bin/wx-config",
     //},
     "C_Cpp.dimInactiveRegions": true,
     "files.associations": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "cmake.configureSettings": {
         "BUILD_EXPERIMENTAL_FEATURES":true,
         "BUILD_STATIC_BINARIES":false,
+        "BUILD_OpenMP":true,
     },
     //"cmake.configureEnvironment": {
     //    "WX_CONFIG":"/Users/rohoua/work/software/wx/bin/wx-config",
@@ -16,5 +17,9 @@
     "files.associations": {
         "string": "cpp",
         "filesystem": "cpp"
+    },
+    "files.associations": {
+        "limits": "cpp",
+        "iostream": "cpp"
     },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,4 @@
         "string": "cpp",
         "filesystem": "cpp"
     },
-    "files.associations": {
-        "limits": "cpp",
-        "iostream": "cpp"
-    },
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,19 @@ if (BUILD_EXPERIMENTAL_FEATURES)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DEXPERIMENTAL")
 endif(BUILD_EXPERIMENTAL_FEATURES)
 
+# OpenMP build option
+option(BUILD_OpenMP "Enable OpenMP for multithreading" OFF)
+if (BUILD_OpenMP)
+    find_package(OpenMP)
+    if(OpenMP_FOUND OR OpenMP_CXX_FOUND)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+    else()
+        message(FATAL_ERROR "Build step for OpenMP failed.")
+    endif()
+endif(BUILD_OpenMP)
+
 #
 # Let's link in static libraries
 #


### PR DESCRIPTION
I created a new branch that enables OpenMP using CMake. Two files were changed.
1. settings.json in .vscode
2. CMakeLists.txt

I tested it by running azimuthal_average with different number of threads and compared run times within the docker container and it worked both on my local machine and on tgrant0000.

~ Aqyan