### PR TITLE
EER support in the GUI

### DIFF
--- a/src/core/assets.cpp
+++ b/src/core/assets.cpp
@@ -39,6 +39,8 @@ MovieAsset::MovieAsset()
 	parent_id = -1;
 	position_in_stack = 1;
 	number_of_frames = 0;
+	eer_frames_per_image = 0;
+	eer_super_res_factor = 1;
 	x_size = 0;
 	y_size = 0;
 	pixel_size = 0;
@@ -79,6 +81,8 @@ MovieAsset::MovieAsset(wxString wanted_filename)
 	position_in_stack = 1;
 
 	number_of_frames = 0;
+	eer_frames_per_image = 0;
+	eer_super_res_factor = 1;
 	x_size = 0;
 	y_size = 0;
 	pixel_size = 0;
@@ -142,6 +146,15 @@ void MovieAsset::Update(wxString wanted_filename, int assume_number_of_frames)
 			number_of_frames = temp_tif.ReturnNumberOfSlices();
 			temp_tif.CloseFile();
 		}
+		else if (filename.GetExt().IsSameAs("eer",false))
+		{
+			EerFile temp_eer;
+			is_valid = temp_eer.OpenFile(filename.GetFullPath().ToStdString(), false, false, assume_number_of_frames,eer_super_res_factor,eer_frames_per_image);
+			x_size = temp_eer.ReturnXSize();
+			y_size = temp_eer.ReturnYSize();
+			number_of_frames = temp_eer.ReturnNumberOfSlices();
+			temp_eer.CloseFile();
+		}
 		else
 		{
 			is_valid = false;
@@ -159,6 +172,8 @@ void MovieAsset::CopyFrom(Asset *other_asset)
 	x_size = casted_asset->x_size;
 	y_size = casted_asset->y_size;
 	number_of_frames = casted_asset->number_of_frames;
+	eer_frames_per_image = casted_asset->eer_frames_per_image;
+	eer_super_res_factor = casted_asset->eer_super_res_factor;
 	filename = casted_asset->filename;
 	pixel_size = casted_asset->pixel_size;
 	microscope_voltage = casted_asset->microscope_voltage;

--- a/src/core/assets.h
+++ b/src/core/assets.h
@@ -35,6 +35,8 @@ class MovieAsset : public Asset {
 	int x_size;
 	int y_size;
 	int number_of_frames;
+	int eer_frames_per_image;
+	int eer_super_res_factor;
 	
 
 	double pixel_size;

--- a/src/core/database.cpp
+++ b/src/core/database.cpp
@@ -959,7 +959,7 @@ bool Database::DoesColumnExist(wxString table_name, wxString column_name)
 	return return_code == SQLITE_OK;
 }
 
-void Database::GetMovieImportDefaults(float &voltage, float &spherical_aberration, float &pixel_size, float &exposure_per_frame, bool &movies_are_gain_corrected, wxString &gain_reference_filename, bool &movies_are_dark_corrected, wxString dark_reference_filename, bool &resample_movies, float &desired_pixel_size, bool &correct_mag_distortion, float &mag_distortion_angle, float &mag_distortion_major_scale, float &mag_distortion_minor_scale, bool &protein_is_white)
+void Database::GetMovieImportDefaults(float &voltage, float &spherical_aberration, float &pixel_size, float &exposure_per_frame, bool &movies_are_gain_corrected, wxString &gain_reference_filename, bool &movies_are_dark_corrected, wxString dark_reference_filename, bool &resample_movies, float &desired_pixel_size, bool &correct_mag_distortion, float &mag_distortion_angle, float &mag_distortion_major_scale, float &mag_distortion_minor_scale, bool &protein_is_white, int &eer_super_res_factor, int &eer_frames_per_image)
 {
 	MyDebugAssertTrue(is_open == true, "database not open!");
 
@@ -985,6 +985,8 @@ void Database::GetMovieImportDefaults(float &voltage, float &spherical_aberratio
 	mag_distortion_major_scale = sqlite3_column_double(sqlite_statement, 13);
 	mag_distortion_minor_scale = sqlite3_column_double(sqlite_statement, 14);
 	protein_is_white = sqlite3_column_int(sqlite_statement,15);
+	eer_super_res_factor = sqlite3_column_int(sqlite_statement,16);
+	eer_frames_per_image = sqlite3_column_int(sqlite_statement,17);
 
 	Finalize(sqlite_statement);
 }
@@ -1168,12 +1170,12 @@ void Database::EndBatchInsert()
 
 void Database::BeginMovieAssetInsert()
 {
-	BeginBatchInsert("MOVIE_ASSETS", 19, "MOVIE_ASSET_ID", "NAME", "FILENAME", "POSITION_IN_STACK", "X_SIZE", "Y_SIZE", "NUMBER_OF_FRAMES", "VOLTAGE", "PIXEL_SIZE", "DOSE_PER_FRAME", "SPHERICAL_ABERRATION","GAIN_FILENAME", "DARK_FILENAME", "OUTPUT_BINNING_FACTOR", "CORRECT_MAG_DISTORTION", "MAG_DISTORTION_ANGLE", "MAG_DISTORTION_MAJOR_SCALE", "MAG_DISTORTION_MINOR_SCALE", "PROTEIN_IS_WHITE");
+	BeginBatchInsert("MOVIE_ASSETS", 21, "MOVIE_ASSET_ID", "NAME", "FILENAME", "POSITION_IN_STACK", "X_SIZE", "Y_SIZE", "NUMBER_OF_FRAMES", "VOLTAGE", "PIXEL_SIZE", "DOSE_PER_FRAME", "SPHERICAL_ABERRATION","GAIN_FILENAME", "DARK_FILENAME", "OUTPUT_BINNING_FACTOR", "CORRECT_MAG_DISTORTION", "MAG_DISTORTION_ANGLE", "MAG_DISTORTION_MAJOR_SCALE", "MAG_DISTORTION_MINOR_SCALE", "PROTEIN_IS_WHITE", "EER_SUPER_RES_FACTOR", "EER_FRAMES_PER_IMAGE");
 }
 
-void Database::AddNextMovieAsset(int movie_asset_id,  wxString name, wxString filename, int position_in_stack, int x_size, int y_size, int number_of_frames, double voltage, double pixel_size, double dose_per_frame, double spherical_aberration, wxString gain_filename, wxString dark_filename, double output_binning_factor, int correct_mag_distortion, float mag_distortion_angle, float mag_distortion_major_scale, float mag_distortion_minor_scale, int protein_is_white)
+void Database::AddNextMovieAsset(int movie_asset_id,  wxString name, wxString filename, int position_in_stack, int x_size, int y_size, int number_of_frames, double voltage, double pixel_size, double dose_per_frame, double spherical_aberration, wxString gain_filename, wxString dark_filename, double output_binning_factor, int correct_mag_distortion, float mag_distortion_angle, float mag_distortion_major_scale, float mag_distortion_minor_scale, int protein_is_white, int eer_super_res_factor, int eer_frames_per_image)
 {
-	AddToBatchInsert("ittiiiirrrrttrirrri", movie_asset_id, name.ToUTF8().data(), filename.ToUTF8().data(), position_in_stack, x_size, y_size, number_of_frames, voltage, pixel_size, dose_per_frame, spherical_aberration,gain_filename.ToUTF8().data(), dark_filename.ToUTF8().data(), output_binning_factor, correct_mag_distortion, mag_distortion_angle, mag_distortion_major_scale, mag_distortion_minor_scale,protein_is_white);
+	AddToBatchInsert("ittiiiirrrrttrirrriii", movie_asset_id, name.ToUTF8().data(), filename.ToUTF8().data(), position_in_stack, x_size, y_size, number_of_frames, voltage, pixel_size, dose_per_frame, spherical_aberration,gain_filename.ToUTF8().data(), dark_filename.ToUTF8().data(), output_binning_factor, correct_mag_distortion, mag_distortion_angle, mag_distortion_major_scale, mag_distortion_minor_scale,protein_is_white, eer_super_res_factor, eer_frames_per_image);
 }
 
 /*
@@ -1752,7 +1754,7 @@ MovieAsset Database::GetNextMovieAsset()
 	MovieAsset temp_asset;
 	int correct_mag_distortion;
 
-	GetFromBatchSelect("itfiiiirrrrttrirrri", &temp_asset.asset_id, &temp_asset.asset_name, &temp_asset.filename, &temp_asset.position_in_stack, &temp_asset.x_size, &temp_asset.y_size, &temp_asset.number_of_frames, &temp_asset.microscope_voltage, &temp_asset.pixel_size, &temp_asset.dose_per_frame, &temp_asset.spherical_aberration, &temp_asset.gain_filename, &temp_asset.dark_filename, & temp_asset.output_binning_factor, &correct_mag_distortion, &temp_asset.mag_distortion_angle, &temp_asset.mag_distortion_major_scale, &temp_asset.mag_distortion_minor_scale, &temp_asset.protein_is_white);
+	GetFromBatchSelect("itfiiiirrrrttrirrriii", &temp_asset.asset_id, &temp_asset.asset_name, &temp_asset.filename, &temp_asset.position_in_stack, &temp_asset.x_size, &temp_asset.y_size, &temp_asset.number_of_frames, &temp_asset.microscope_voltage, &temp_asset.pixel_size, &temp_asset.dose_per_frame, &temp_asset.spherical_aberration, &temp_asset.gain_filename, &temp_asset.dark_filename, & temp_asset.output_binning_factor, &correct_mag_distortion, &temp_asset.mag_distortion_angle, &temp_asset.mag_distortion_major_scale, &temp_asset.mag_distortion_minor_scale, &temp_asset.protein_is_white, &temp_asset.eer_super_res_factor, &temp_asset.eer_frames_per_image);
 	temp_asset.correct_mag_distortion = correct_mag_distortion;
 	temp_asset.total_dose = temp_asset.dose_per_frame * temp_asset.number_of_frames;
 	return temp_asset;

--- a/src/core/database.h
+++ b/src/core/database.h
@@ -119,7 +119,7 @@ public :
 	void GetUniquePickingJobIDs(int *picking_job_ids, int number_of_picking_jobs);
 	void GetUniqueIDsOfImagesWithCTFEstimations(int *image_ids, int &number_of_image_ids);
 
-	void GetMovieImportDefaults(float &voltage, float &spherical_aberration, float &pixel_size, float &exposure_per_frame, bool &movies_are_gain_corrected, wxString &gain_reference_filename, bool &movies_are_dark_corrected, wxString dark_reference_filename, bool &resample_movies, float &desired_pixel_size, bool &correct_mag_distortion, float &mag_distortion_angle, float &mag_distortion_major_scale, float &mag_distortion_minor_scale, bool &protein_is_white);
+	void GetMovieImportDefaults(float &voltage, float &spherical_aberration, float &pixel_size, float &exposure_per_frame, bool &movies_are_gain_corrected, wxString &gain_reference_filename, bool &movies_are_dark_corrected, wxString dark_reference_filename, bool &resample_movies, float &desired_pixel_size, bool &correct_mag_distortion, float &mag_distortion_angle, float &mag_distortion_major_scale, float &mag_distortion_minor_scale, bool &protein_is_white, int &eer_super_res_factor, int &eer_frames_per_image);
 	void GetImageImportDefaults(float &voltage, float &spherical_aberration, float &pixel_size, bool &protein_is_white);
 
 	void GetActiveDefocusValuesByImageID(long wanted_image_id, float &defocus_1, float &defocus_2, float &defocus_angle, float &phase_shift, float &amplitude_contrast, float &tilt_angle, float &tilt_axis);
@@ -137,7 +137,7 @@ public :
 	void DeleteRunProfile(int wanted_id);
 
 	void BeginMovieAssetInsert();
-	void AddNextMovieAsset(int movie_asset_id,  wxString name, wxString filename, int position_in_stack, int x_size, int y_size, int number_of_frames, double voltage, double pixel_size, double dose_per_frame, double spherical_aberration, wxString gain_filename, wxString dark_reference, double output_binning_factor, int correct_mag_distortion, float mag_distortion_angle, float mag_distortion_major_scale, float mag_distortion_minor_scale, int protein_is_white);
+	void AddNextMovieAsset(int movie_asset_id,  wxString name, wxString filename, int position_in_stack, int x_size, int y_size, int number_of_frames, double voltage, double pixel_size, double dose_per_frame, double spherical_aberration, wxString gain_filename, wxString dark_reference, double output_binning_factor, int correct_mag_distortion, float mag_distortion_angle, float mag_distortion_major_scale, float mag_distortion_minor_scale, int protein_is_white, int eer_super_res_factor, int eer_frames_per_image);
 	void EndMovieAssetInsert();
 
 	void UpdateNumberOfFramesForAMovieAsset(int movie_asset_id, int new_number_of_frames);
@@ -172,7 +172,7 @@ public :
 	bool CreateParticlePickingResultsTable(const int &picking_job_id) {return CreateTable(wxString::Format("PARTICLE_PICKING_RESULTS_%i",picking_job_id),"piirrrirrr","POSITION_ID","PICKING_ID","PARENT_IMAGE_ASSET_ID","X_POSITION", "Y_POSITION","PEAK_HEIGHT","TEMPLATE_ASSET_ID","TEMPLATE_PSI","TEMPLATE_THETA","TEMPLATE_PHI");};
 
 	bool CreateImageAssetTable() {return CreateTable("IMAGE_ASSETS", "pttiiiiiirrri", "IMAGE_ASSET_ID", "NAME", "FILENAME", "POSITION_IN_STACK", "PARENT_MOVIE_ID", "ALIGNMENT_ID", "CTF_ESTIMATION_ID", "X_SIZE", "Y_SIZE", "PIXEL_SIZE", "VOLTAGE", "SPHERICAL_ABERRATION","PROTEIN_IS_WHITE");};
-	bool CreateMovieAssetTable() {return CreateTable("MOVIE_ASSETS", "pttiiiirrrrttrirrri", "MOVIE_ASSET_ID", "NAME", "FILENAME", "POSITION_IN_STACK", "X_SIZE", "Y_SIZE", "NUMBER_OF_FRAMES", "VOLTAGE", "PIXEL_SIZE", "DOSE_PER_FRAME", "SPHERICAL_ABERRATION", "GAIN_FILENAME", "DARK_FILENAME", "OUTPUT_BINNING_FACTOR", "CORRECT_MAG_DISTORTION", "MAG_DISTORTION_ANGLE", "MAG_DISTORTION_MAJOR_SCALE", "MAG_DISTORTION_MINOR_SCALE","PROTEIN_IS_WHITE");};
+	bool CreateMovieAssetTable() {return CreateTable("MOVIE_ASSETS", "pttiiiirrrrttrirrriii", "MOVIE_ASSET_ID", "NAME", "FILENAME", "POSITION_IN_STACK", "X_SIZE", "Y_SIZE", "NUMBER_OF_FRAMES", "VOLTAGE", "PIXEL_SIZE", "DOSE_PER_FRAME", "SPHERICAL_ABERRATION", "GAIN_FILENAME", "DARK_FILENAME", "OUTPUT_BINNING_FACTOR", "CORRECT_MAG_DISTORTION", "MAG_DISTORTION_ANGLE", "MAG_DISTORTION_MAJOR_SCALE", "MAG_DISTORTION_MINOR_SCALE", "PROTEIN_IS_WHITE", "EER_SUPER_RES_FACTOR", "EER_FRAMES_PER_IMAGE");};
 
 	bool CreateVolumeAssetTable() {return CreateTable("VOLUME_ASSETS", "pttiriiitt", "VOLUME_ASSET_ID", "NAME", "FILENAME", "RECONSTRUCTION_JOB_ID", "PIXEL_SIZE", "X_SIZE", "Y_SIZE", "Z_SIZE", "HALF_MAP1_FILENAME", "HALF_MAP2_FILENAME");};
 	bool CreateVolumeGroupListTable() {return  CreateTable("VOLUME_GROUP_LIST", "pti", "GROUP_ID", "GROUP_NAME", "LIST_ID" );};
@@ -211,7 +211,7 @@ public :
 	bool CreateClassificationSelectionListTable() {return CreateTable("CLASSIFICATION_SELECTION_LIST", "Ptlllii", "SELECTION_ID", "SELECTION_NAME", "CREATION_DATE", "REFINEMENT_PACKAGE_ID", "CLASSIFICATION_ID", "NUMBER_OF_CLASSES", "NUMBER_OF_SELECTIONS");};
 	bool CreateClassificationSelectionTable(const long selection_id) {return CreateTable(wxString::Format("CLASSIFICATION_SELECTION_%li", selection_id), "pl", "SELECTION_NUMBER", "CLASS_AVERAGE_NUMBER");};
 
-	bool CreateMovieImportDefaultsTable() {return CreateTable("MOVIE_IMPORT_DEFAULTS", "prrrrititirirrri", "NUMBER", "VOLTAGE", "SPHERICAL_ABERRATION", "PIXEL_SIZE", "EXPOSURE_PER_FRAME", "MOVIES_ARE_GAIN_CORRECTED", "GAIN_REFERENCE_FILENAME", "MOVIES_ARE_DARK_CORRECTED", "DARK_REFERENCE_FILENAME", "RESAMPLE_MOVIES", "DESIRED_PIXEL_SIZE", "CORRECT_MAG_DISTORTION", "MAG_DISTORTION_ANGLE", "MAG_DISTORTION_MAJOR_SCALE", "MAG_DISTORTION_MINOR_SCALE", "PROTEIN_IS_WHITE" );};
+	bool CreateMovieImportDefaultsTable() {return CreateTable("MOVIE_IMPORT_DEFAULTS", "prrrrititirirrriii", "NUMBER", "VOLTAGE", "SPHERICAL_ABERRATION", "PIXEL_SIZE", "EXPOSURE_PER_FRAME", "MOVIES_ARE_GAIN_CORRECTED", "GAIN_REFERENCE_FILENAME", "MOVIES_ARE_DARK_CORRECTED", "DARK_REFERENCE_FILENAME", "RESAMPLE_MOVIES", "DESIRED_PIXEL_SIZE", "CORRECT_MAG_DISTORTION", "MAG_DISTORTION_ANGLE", "MAG_DISTORTION_MAJOR_SCALE", "MAG_DISTORTION_MINOR_SCALE", "PROTEIN_IS_WHITE", "EER_SUPER_RES_FACTOR", "EER_FRAMES_PER_IMAGE" );};
 	bool CreateImageImportDefaultsTable() {return CreateTable("IMAGE_IMPORT_DEFAULTS", "prrri", "NUMBER", "VOLTAGE", "SPHERICAL_ABERRATION", "PIXEL_SIZE", "PROTEIN_IS_WHITE");};
 
 	bool CreateStartupListTable() { return CreateTable("STARTUP_LIST", "Pltiirriirrrir", "STARTUP_ID", "REFINEMENT_PACKAGE_ASSET_ID", "NAME", "NUMBER_OF_STARTS", "NUMBER_OF_CYCLES", "INITIAL_RES_LIMIT", "FINAL_RES_LIMIT", "AUTO_MASK", "AUTO_PERCENT_USED", "INITIAL_PERCENT_USED", "FINAL_PERCENT_USED", "MASK_RADIUS", "APPLY_LIKELIHOOD_BLURRING", "SMOOTHING_FACTOR");};

--- a/src/core/eer_file.cpp
+++ b/src/core/eer_file.cpp
@@ -317,7 +317,7 @@ void EerFile::DecodeToFloatArray(int start_eer_frame, int finish_eer_frame, floa
 				y = ((positions[i] >> 12) << 2) | ((symbols[i] & 12) >> 2); //render16K;  4096 = 2^12, 12 = 00001100b
 			}
 
-			current_address = y * logical_dimension_y + x;
+			current_address = y * logical_dimension_y * super_res_factor + x;
 
 			output_array[current_address] += 1.0f;
 		}

--- a/src/core/eer_file.cpp
+++ b/src/core/eer_file.cpp
@@ -231,17 +231,24 @@ void EerFile::DecodeToFloatArray(int start_eer_frame, int finish_eer_frame, floa
 	for ( current_address=0; current_address < logical_dimension_x*logical_dimension_y*super_res_factor*super_res_factor; current_address++) { output_array[current_address] = 0.0f; }
 
 	/*
-	 * Decode into a list of events
+	 * Max number of electrons in a frame
 	 */
+	unsigned long long max_electrons = 0;
 	for (int iframe = start_eer_frame; iframe <= finish_eer_frame; iframe++)
 	{
+		max_electrons = std::max(max_electrons,frame_sizes[iframe]*2); // at 4 bits per electron (very permissive bound!)
+	}
 
+
+	/*
+	 * Decode into a list of events
+	 */
+	unsigned int * positions = new unsigned int[max_electrons];
+	unsigned char * symbols = new unsigned char[max_electrons];
+	for (int iframe = start_eer_frame; iframe <= finish_eer_frame; iframe++)
+	{
 		long long pos = frame_starts[iframe];
 		unsigned int npixels = 0, nelectrons = 0;
-		const int max_electrons = frame_sizes[iframe] * 2; // at 4 bits per electron (very permissive bound!)
-		unsigned int * positions = new unsigned int[max_electrons];
-		unsigned char * symbols = new unsigned char[max_electrons];
-
 		unsigned int bit_pos = 0; // 4 K * 4 K * 11 bit << 2 ** 32
 		unsigned char rle, subpixel;
 		long long first_byte;
@@ -325,6 +332,9 @@ void EerFile::DecodeToFloatArray(int start_eer_frame, int finish_eer_frame, floa
 			output_array[current_address] += 1.0f;
 		}
 	}
+
+	delete [] positions;
+	delete [] symbols;
 }
 
 void EerFile::WriteSliceToDisk(int slice_number, float * input_array)

--- a/src/core/eer_file.cpp
+++ b/src/core/eer_file.cpp
@@ -1,6 +1,7 @@
 #include "core_headers.h"
 EerFile::EerFile()
 {
+	fh = NULL;
 	tif = NULL;
 	logical_dimension_x = 0;
 	logical_dimension_y = 0;
@@ -74,6 +75,8 @@ void EerFile::CloseFile()
 {
 	if (tif != NULL) TIFFClose(tif);
 	tif = NULL;
+	if (fh != NULL) fclose(fh);
+	fh = NULL;
 }
 
 void EerFile::PrintInfo()
@@ -95,7 +98,7 @@ void EerFile::PrintInfo()
 bool EerFile::ReadLogicalDimensionsFromDisk(bool check_only_the_first_image)
 {
 	MyDebugAssertTrue(tif != NULL,"File must be open");
-	MyDebugAssertTrue(fh != NULL,"File must be open");
+	MyDebugAssertTrue(fh != NULL,"File must be open: %s", filename.GetFullPath());
 	MyDebugAssertFalse(number_of_eer_frames_per_image == 0, "Number of EER frames per image has not yet been set. Cannot work out logical dimensions.");
 	/*
 	 * Since the file was already open, EerOpen has already read in the first dictionary

--- a/src/gui/AlignMoviesPanel.cpp
+++ b/src/gui/AlignMoviesPanel.cpp
@@ -529,6 +529,9 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 
 	float current_pixel_size;
 
+	int current_eer_frames_per_image;
+	int current_eer_super_res_factor;
+
 	float current_acceleration_voltage;
 	float current_dose_per_frame;
 	float current_pre_exposure;
@@ -561,8 +564,6 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 	float mag_distortion_angle;
 	float mag_distortion_major_axis_scale;
 	float mag_distortion_minor_axis_scale;
-
-	const int eer_frames_per_image = 0;
 
 
 	// read the options form the gui..
@@ -704,6 +705,8 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 			movie_is_dark_corrected = false;
 		}
 
+		current_eer_frames_per_image = movie_asset_panel->ReturnAssetEerFramesPerImage(active_group.members[counter]);
+		current_eer_super_res_factor = movie_asset_panel->ReturnAssetEerSuperResFactor(active_group.members[counter]);
 
 		output_binning_factor = movie_asset_panel->ReturnAssetBinningFactor(active_group.members[counter]);
 
@@ -720,7 +723,7 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 		std::string aligned_frames_filename = "/dev/null";
 		std::string output_shift_text_file = "/dev/null";
 
-		current_job_package.AddJob("ssfffbbfifbiifffbsbsfbfffbtbtiiiibtti",current_filename.c_str(), //0
+		current_job_package.AddJob("ssfffbbfifbiifffbsbsfbfffbtbtiiiibttii",current_filename.c_str(), //0
 														output_filename.ToUTF8().data(),
 														current_pixel_size,
 														float(minimum_shift),
@@ -756,7 +759,8 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 														saved_aligned_frames,
 														aligned_frames_filename.c_str(),
 														output_shift_text_file.c_str(),
-														eer_frames_per_image);
+														current_eer_frames_per_image,
+														current_eer_super_res_factor);
 
 		my_progress_dialog->Update(counter + 1);
 	}

--- a/src/gui/FindCTFPanel.cpp
+++ b/src/gui/FindCTFPanel.cpp
@@ -600,7 +600,8 @@ void MyFindCTFPanel::StartEstimationClick( wxCommandEvent& event )
 
 	bool determine_tilt;
 
-	const int eer_frames_per_image = 0;
+	int current_eer_frames_per_image = 0;
+	int current_eer_super_res_factor = 1;
 
 	// allocate space for the buffered results..
 
@@ -742,6 +743,9 @@ void MyFindCTFPanel::StartEstimationClick( wxCommandEvent& event )
 				movie_mag_distortion_major_scale = 1.0;
 				movie_mag_distortion_minor_scale = 1.0;
             }
+
+			current_eer_frames_per_image = current_movie->eer_frames_per_image;
+			current_eer_super_res_factor = current_movie->eer_super_res_factor;
         }
 		else
 		{
@@ -749,11 +753,13 @@ void MyFindCTFPanel::StartEstimationClick( wxCommandEvent& event )
 			movie_is_gain_corrected = true;
 			current_dark_filename = "";
 			movie_is_dark_corrected = true;
+			current_eer_super_res_factor = 1;
+			current_eer_frames_per_image = 0;
 		}
 
 		const int number_of_threads = 1;
 
-		current_job_package.AddJob("sbisffffifffffbfbfffbffbbsbsbfffbfffbii",	input_filename.c_str(), // 0
+		current_job_package.AddJob("sbisffffifffffbfbfffbffbbsbsbfffbfffbiii",	input_filename.c_str(), // 0
 																	input_is_a_movie, // 1
 																	number_of_frames_to_average, //2
 																	output_diagnostic_filename.c_str(), // 3
@@ -791,7 +797,8 @@ void MyFindCTFPanel::StartEstimationClick( wxCommandEvent& event )
 																	known_phase_shift,
 																	determine_tilt,
 																	number_of_threads,
-																	eer_frames_per_image);
+																	current_eer_frames_per_image,
+																	current_eer_super_res_factor);
 
 		my_progress_dialog->Update(counter + 1);
 	}

--- a/src/gui/MyMovieAssetPanel.cpp
+++ b/src/gui/MyMovieAssetPanel.cpp
@@ -307,6 +307,8 @@ void MyMovieAssetPanel::FillAssetSpecificContentsList()
 		ContentsListBox->InsertColumn(14,"Dist. major scale", wxLIST_FORMAT_LEFT, wxLIST_AUTOSIZE_USEHEADER );
 		ContentsListBox->InsertColumn(15,"Dist. minor scale", wxLIST_FORMAT_LEFT, wxLIST_AUTOSIZE_USEHEADER );
 		ContentsListBox->InsertColumn(16,"Particles are white?", wxLIST_FORMAT_LEFT, wxLIST_AUTOSIZE_USEHEADER );
+		ContentsListBox->InsertColumn(17,"EER frames per image", wxLIST_FORMAT_LEFT, wxLIST_AUTOSIZE_USEHEADER );
+		ContentsListBox->InsertColumn(18,"EER super res factor", wxLIST_FORMAT_LEFT, wxLIST_AUTOSIZE_USEHEADER );
 
 /*
 		for (long counter = 0; counter < all_groups_list->groups[selected_group].number_of_members; counter++)
@@ -375,6 +377,10 @@ wxString MyMovieAssetPanel::ReturnItemText(long item, long column) const
 	    	return wxString::Format(wxT("%.3f"), all_assets_list->ReturnMovieAssetPointer(all_groups_list->ReturnGroupMember(selected_group, item))->mag_distortion_minor_scale);
 	    case 16:
 			return wxString::Format(wxT("%i"), all_assets_list->ReturnMovieAssetPointer(all_groups_list->ReturnGroupMember(selected_group, item))->protein_is_white);
+		case 17:
+			return wxString::Format(wxT("%i"), all_assets_list->ReturnMovieAssetPointer(all_groups_list->ReturnGroupMember(selected_group, item))->eer_frames_per_image);
+		case 18:
+			return wxString::Format(wxT("%i"), all_assets_list->ReturnMovieAssetPointer(all_groups_list->ReturnGroupMember(selected_group, item))->eer_super_res_factor);
 		default :
 	       MyPrintWithDetails("Error, asking for column (%li) which does not exist", column);
 	       return "";
@@ -430,6 +436,16 @@ wxString MyMovieAssetPanel::ReturnAssetDarkFilename(long wanted_asset)
 float MyMovieAssetPanel::ReturnAssetBinningFactor(long wanted_asset)
 {
 	return all_assets_list->ReturnMovieAssetPointer(wanted_asset)->output_binning_factor;
+}
+
+int MyMovieAssetPanel::ReturnAssetEerFramesPerImage(long wanted_asset)
+{
+	return all_assets_list->ReturnMovieAssetPointer(wanted_asset)->eer_frames_per_image;
+}
+
+int MyMovieAssetPanel::ReturnAssetEerSuperResFactor(long wanted_asset)
+{
+	return all_assets_list->ReturnMovieAssetPointer(wanted_asset)->eer_super_res_factor;
 }
 
 int MyMovieAssetPanel::ReturnAssetID(long wanted_asset)

--- a/src/gui/MyMovieAssetPanel.h
+++ b/src/gui/MyMovieAssetPanel.h
@@ -33,6 +33,8 @@ class MyMovieAssetPanel : public MyAssetParentPanel
 		double ReturnAssetPreExposureAmount(long wanted_asset);
 		float ReturnAssetSphericalAbberation(long wanted_asset);
 		bool ReturnAssetProteinIsWhite(long wanted_asset);
+		int ReturnAssetEerFramesPerImage(long wanted_asset);
+		int ReturnAssetEerSuperResFactor(long wanted_asset);
 		int ReturnAssetID(long wanted_asset);
 		wxString ReturnAssetGainFilename(long wanted_asset);
 		wxString ReturnAssetDarkFilename(long wanted_asset);

--- a/src/gui/ProjectX_gui.cpp
+++ b/src/gui/ProjectX_gui.cpp
@@ -5090,12 +5090,32 @@ MovieImportDialog::MovieImportDialog( wxWindow* parent, wxWindowID id, const wxS
 
 	bSizer26->Add( bSizer30, 0, wxEXPAND, 5 );
 
+	wxBoxSizer* bSizer291;
+	bSizer291 = new wxBoxSizer( wxHORIZONTAL );
+
+	EerSuperResFactorStaticText = new wxStaticText( this, wxID_ANY, wxT("EER super res. factor :"), wxDefaultPosition, wxDefaultSize, 0 );
+	EerSuperResFactorStaticText->Wrap( -1 );
+	EerSuperResFactorStaticText->Enable( false );
+
+	bSizer291->Add( EerSuperResFactorStaticText, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+
+	wxString EerSuperResFactorChoiceChoices[] = { wxT("1"), wxT("2"), wxT("4") };
+	int EerSuperResFactorChoiceNChoices = sizeof( EerSuperResFactorChoiceChoices ) / sizeof( wxString );
+	EerSuperResFactorChoice = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, EerSuperResFactorChoiceNChoices, EerSuperResFactorChoiceChoices, 0 );
+	EerSuperResFactorChoice->SetSelection( 0 );
+	EerSuperResFactorChoice->Enable( false );
+
+	bSizer291->Add( EerSuperResFactorChoice, 50, wxALL, 5 );
+
+
+	bSizer26->Add( bSizer291, 1, wxEXPAND, 5 );
+
 	wxBoxSizer* bSizer29;
 	bSizer29 = new wxBoxSizer( wxHORIZONTAL );
 
-	m_staticText20 = new wxStaticText( this, wxID_ANY, wxT("Pixel Size (Å) :"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText20->Wrap( -1 );
-	bSizer29->Add( m_staticText20, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+	PixelSizeStaticText = new wxStaticText( this, wxID_ANY, wxT("Pixel Size (Å) :"), wxDefaultPosition, wxDefaultSize, 0 );
+	PixelSizeStaticText->Wrap( -1 );
+	bSizer29->Add( PixelSizeStaticText, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
 	PixelSizeText = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer29->Add( PixelSizeText, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -5103,12 +5123,29 @@ MovieImportDialog::MovieImportDialog( wxWindow* parent, wxWindowID id, const wxS
 
 	bSizer26->Add( bSizer29, 0, wxEXPAND, 5 );
 
+	wxBoxSizer* bSizer2911;
+	bSizer2911 = new wxBoxSizer( wxHORIZONTAL );
+
+	EerNumberOfFramesStaticText = new wxStaticText( this, wxID_ANY, wxT("EER number of frames to average :"), wxDefaultPosition, wxDefaultSize, 0 );
+	EerNumberOfFramesStaticText->Wrap( -1 );
+	EerNumberOfFramesStaticText->Enable( false );
+
+	bSizer2911->Add( EerNumberOfFramesStaticText, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+
+	EerNumberOfFramesSpinCtrl = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 100000, 25 );
+	EerNumberOfFramesSpinCtrl->Enable( false );
+
+	bSizer2911->Add( EerNumberOfFramesSpinCtrl, 50, wxALL, 5 );
+
+
+	bSizer26->Add( bSizer2911, 1, wxEXPAND, 5 );
+
 	wxBoxSizer* bSizer32;
 	bSizer32 = new wxBoxSizer( wxHORIZONTAL );
 
-	m_staticText22 = new wxStaticText( this, wxID_ANY, wxT("Exposure per frame (e¯/Å²) :"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText22->Wrap( -1 );
-	bSizer32->Add( m_staticText22, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+	ExposurePerFrameStaticText = new wxStaticText( this, wxID_ANY, wxT("Exposure per frame (e¯/Å²) :"), wxDefaultPosition, wxDefaultSize, 0 );
+	ExposurePerFrameStaticText->Wrap( -1 );
+	bSizer32->Add( ExposurePerFrameStaticText, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
 	DoseText = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 	bSizer32->Add( DoseText, 50, wxALIGN_CENTER_VERTICAL|wxALL, 5 );

--- a/src/gui/ProjectX_gui.h
+++ b/src/gui/ProjectX_gui.h
@@ -1445,9 +1445,13 @@ class MovieImportDialog : public wxDialog
 		wxComboBox* VoltageCombo;
 		wxStaticText* m_staticText21;
 		wxTextCtrl* CsText;
-		wxStaticText* m_staticText20;
+		wxStaticText* EerSuperResFactorStaticText;
+		wxChoice* EerSuperResFactorChoice;
+		wxStaticText* PixelSizeStaticText;
 		wxTextCtrl* PixelSizeText;
-		wxStaticText* m_staticText22;
+		wxStaticText* EerNumberOfFramesStaticText;
+		wxSpinCtrl* EerNumberOfFramesSpinCtrl;
+		wxStaticText* ExposurePerFrameStaticText;
 		wxTextCtrl* DoseText;
 		wxCheckBox* ApplyDarkImageCheckbox;
 		wxFilePickerCtrl* DarkFilePicker;

--- a/src/programs/ctffind/ctffind.cpp
+++ b/src/programs/ctffind/ctffind.cpp
@@ -1126,6 +1126,7 @@ void CtffindApp::DoInteractiveUserInput()
 	float known_phase_shift = 0.0;
 	int desired_number_of_threads = 1;
 	int eer_frames_per_image = 0;
+	int eer_super_res_factor = 1;
 
 
 	// Things we need for old school input
@@ -1488,8 +1489,9 @@ void CtffindApp::DoInteractiveUserInput()
 				if (FilenameExtensionMatches(input_filename,"eer"))
 				{
 					eer_frames_per_image = my_input->GetIntFromUser("Number of EER frames per image","If the input movie is in EER format, we will average EER frames together so that each frame image for alignment has a reasonable exposure","25",1);
+					eer_super_res_factor = my_input->GetIntFromUser("EER super resolution factor","Choose between 1 (no supersampling), 2, or 4 (image pixel size will be 4 times smaller that the camera phyiscal pixel)","1",1,4);
 				}
-				else { eer_frames_per_image = 0; }
+				else { eer_frames_per_image = 0; eer_super_res_factor = 1;}
 
 			}
 			else
@@ -1499,6 +1501,7 @@ void CtffindApp::DoInteractiveUserInput()
 				gain_filename = "";
 				dark_filename = "";
 				eer_frames_per_image = 0;
+				eer_super_res_factor = 1;
 			}
 			defocus_is_known					= my_input->GetYesNoFromUser("Do you already know the defocus?","Answer yes if you already know the defocus and you just want to know the score or fit resolution. If you answer yes, the known astigmatism parameter specified eariler will be ignored","No");
 			if (defocus_is_known)
@@ -1538,6 +1541,7 @@ void CtffindApp::DoInteractiveUserInput()
 			defocus_is_known					= false;
 			desired_number_of_threads			= 1;
 			eer_frames_per_image				= 0;
+			eer_super_res_factor				= 1;
 		}
 
 		delete my_input;
@@ -1545,7 +1549,7 @@ void CtffindApp::DoInteractiveUserInput()
 	}
 
 //	my_current_job.Reset(39);
-	my_current_job.ManualSetArguments("tbitffffifffffbfbfffbffbbsbsbfffbfffbii",	input_filename.c_str(), //1
+	my_current_job.ManualSetArguments("tbitffffifffffbfbfffbffbbsbsbfffbfffbiii",	input_filename.c_str(), //1
 																			input_is_a_movie,
 																			number_of_frames_to_average,
 																			output_diagnostic_filename.c_str(),
@@ -1583,7 +1587,8 @@ void CtffindApp::DoInteractiveUserInput()
 																			known_phase_shift,
 																			determine_tilt,
 																			desired_number_of_threads,
-																			eer_frames_per_image);
+																			eer_frames_per_image,
+																			eer_super_res_factor);
 	}
 
 
@@ -1648,6 +1653,7 @@ bool CtffindApp::DoCalculation()
 	const bool  		determine_tilt						= my_current_job.arguments[36].ReturnBoolArgument();
 	int					desired_number_of_threads			= my_current_job.arguments[37].ReturnIntegerArgument();
 	int					eer_frames_per_image				= my_current_job.arguments[38].ReturnIntegerArgument();
+	int					eer_super_res_factor				= my_current_job.arguments[39].ReturnIntegerArgument();
 
 	// if we are applying a mag distortion, it can change the pixel size, so do that here to make sure it is used forever onwards..
 
@@ -1767,7 +1773,7 @@ bool CtffindApp::DoCalculation()
 	wxDateTime time_finish;
 
 	// Open the input file
-	bool input_file_is_valid = input_file.OpenFile(input_filename, false,false,false,1,eer_frames_per_image);
+	bool input_file_is_valid = input_file.OpenFile(input_filename, false,false,false,eer_super_res_factor,eer_frames_per_image);
 	if (!input_file_is_valid)
 	{
 		SendInfo(wxString::Format("Input movie %s seems to be corrupt. Ctffind results may not be meaningful.\n", input_filename));

--- a/src/programs/unblur/unblur.cpp
+++ b/src/programs/unblur/unblur.cpp
@@ -191,7 +191,6 @@ void UnBlurApp::DoInteractiveUserInput()
 	bool write_out_small_sum_image = false;
 	std::string small_sum_image_filename = "/dev/null";
 
-	my_current_job.Reset(38);
 	my_current_job.ManualSetArguments("ttfffbbfifbiifffbsbsfbfffbtbtiiiibttii",input_filename.c_str(),
 																 output_filename.c_str(),
 																 original_pixel_size,

--- a/src/programs/unblur/unblur.cpp
+++ b/src/programs/unblur/unblur.cpp
@@ -56,6 +56,7 @@ void UnBlurApp::DoInteractiveUserInput()
 	int number_of_frames_for_running_average;
 	int max_threads;
 	int eer_frames_per_image = 0;
+	int eer_super_res_factor = 1;
 
 	bool save_aligned_frames;
 
@@ -134,8 +135,9 @@ void UnBlurApp::DoInteractiveUserInput()
 		if (FilenameExtensionMatches(input_filename,"eer"))
 		{
 			eer_frames_per_image = my_input->GetIntFromUser("Number of EER frames per image","If the input movie is in EER format, we will average EER frames together so that each frame image for alignment has a reasonable exposure","25",1);
+			eer_super_res_factor = my_input->GetIntFromUser("EER super resolution factor","Choose between 1 (no supersampling), 2, or 4 (image pixel size will be 4 times smaller that the camera phyiscal pixel)","1",1,4);
 		}
-		else { eer_frames_per_image = 0; }
+		else { eer_frames_per_image = 0; eer_super_res_factor = 1;}
 	 }
  	 else
  	 {
@@ -157,6 +159,7 @@ void UnBlurApp::DoInteractiveUserInput()
  		 save_aligned_frames = false;
  		 aligned_frames_filename = "";
 		 eer_frames_per_image = 0;
+		 eer_super_res_factor = 1;
  	 }
 
 	correct_mag_distortion = my_input->GetYesNoFromUser("Correct Magnification Distortion?", "If yes, a magnification distortion can be corrected", "no");
@@ -188,8 +191,8 @@ void UnBlurApp::DoInteractiveUserInput()
 	bool write_out_small_sum_image = false;
 	std::string small_sum_image_filename = "/dev/null";
 
-	my_current_job.Reset(37);
-	my_current_job.ManualSetArguments("ttfffbbfifbiifffbsbsfbfffbtbtiiiibtti",input_filename.c_str(),
+	my_current_job.Reset(38);
+	my_current_job.ManualSetArguments("ttfffbbfifbiifffbsbsfbfffbtbtiiiibttii",input_filename.c_str(),
 																 output_filename.c_str(),
 																 original_pixel_size,
 																 minimum_shift_in_angstroms,
@@ -225,7 +228,8 @@ void UnBlurApp::DoInteractiveUserInput()
 																 save_aligned_frames,
 																 aligned_frames_filename.c_str(),
 																 output_shift_text_file.c_str(),
-																 eer_frames_per_image);
+																 eer_frames_per_image,
+																 eer_super_res_factor);
 
 
 }
@@ -287,6 +291,7 @@ bool UnBlurApp::DoCalculation()
 	std::string aligned_frames_filename 			= my_current_job.arguments[34].ReturnStringArgument();
 	std::string output_shift_text_file				= my_current_job.arguments[35].ReturnStringArgument();
 	int			eer_frames_per_image				= my_current_job.arguments[36].ReturnIntegerArgument();
+	int 		eer_super_res_factor				= my_current_job.arguments[37].ReturnIntegerArgument();
 
 	if (is_running_locally == false) max_threads = number_of_threads_requested_on_command_line; // OVERRIDE FOR THE GUI, AS IT HAS TO BE SET ON THE COMMAND LINE...
 
@@ -316,7 +321,7 @@ bool UnBlurApp::DoCalculation()
 		exit(-1);
 	}
 	ImageFile input_file;
-	bool input_file_is_valid = input_file.OpenFile(input_filename, false,false,false,1,eer_frames_per_image);
+	bool input_file_is_valid = input_file.OpenFile(input_filename, false,false,false,eer_super_res_factor,eer_frames_per_image);
 	if (!input_file_is_valid)
 	{
 		SendInfo(wxString::Format("Input movie %s seems to be corrupt. Unblur results may not be meaningful.\n", input_filename));

--- a/src/programs/warp_to_cistem/warp_to_cistem.cpp
+++ b/src/programs/warp_to_cistem/warp_to_cistem.cpp
@@ -712,7 +712,8 @@ bool WarpToCistemApp::DoCalculation()
 	new_project.database.BeginMovieAssetInsert();
 	for (counter = 0; counter < movie_list.number_of_assets; counter++){
 		new_movie_asset = reinterpret_cast <MovieAsset *> (movie_list.assets)[counter];
-		new_project.database.AddNextMovieAsset(new_movie_asset.asset_id, new_movie_asset.asset_name, new_movie_asset.filename.GetFullPath(), 1, new_movie_asset.x_size, new_movie_asset.y_size, new_movie_asset.number_of_frames, new_movie_asset.microscope_voltage, new_movie_asset.pixel_size, new_movie_asset.dose_per_frame, new_movie_asset.spherical_aberration,new_movie_asset.gain_filename,new_movie_asset.dark_filename, new_movie_asset.output_binning_factor, new_movie_asset.correct_mag_distortion, new_movie_asset.mag_distortion_angle, new_movie_asset.mag_distortion_major_scale, new_movie_asset.mag_distortion_minor_scale, new_movie_asset.protein_is_white);
+		// NOTE: EER not yet supported... setting eer_frames_per_image to 0
+		new_project.database.AddNextMovieAsset(new_movie_asset.asset_id, new_movie_asset.asset_name, new_movie_asset.filename.GetFullPath(), 1, new_movie_asset.x_size, new_movie_asset.y_size, new_movie_asset.number_of_frames, new_movie_asset.microscope_voltage, new_movie_asset.pixel_size, new_movie_asset.dose_per_frame, new_movie_asset.spherical_aberration,new_movie_asset.gain_filename,new_movie_asset.dark_filename, new_movie_asset.output_binning_factor, new_movie_asset.correct_mag_distortion, new_movie_asset.mag_distortion_angle, new_movie_asset.mag_distortion_major_scale, new_movie_asset.mag_distortion_minor_scale, new_movie_asset.protein_is_white,1,0);
 		my_progress->Update(counter+1);
 	}
 	new_project.database.EndMovieAssetInsert();


### PR DESCRIPTION
EER movies can be imported in the GUI. Of note:
- the user must specify the pixel size and the exposure per frame AFTER EER supersampling and frame averaging; the GUI design tried to reflect this (e.g. the label of the pixel size and exposure per frame fields changes when an EER movie is being imported)
- there appears to be a bug with EER super sampling (the lower-level EER stuff was only ever tested with no super sampling). With 2x super sampling, movies end up looking like this:
![image](https://user-images.githubusercontent.com/1859633/108022905-55e9c400-6fd6-11eb-9756-1c9d0b27e4f4.png)
I suspect this is not GUI-related, but happening at a lower level
