### PR TITLE
Template matching updates used in pending manuscript

### DIFF
--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -220,10 +220,11 @@ NVCCFLAGS=" -ccbin $CXX"
 
 
 # For now just compile for Volta and Turing arch
-NVCCFLAGS+=" --gpu-architecture=compute_70 --gpu-code=sm_70,sm_75"
-
-
-NVCCFLAGS+=" --default-stream per-thread -m64 -O3 --use_fast_math -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
+#NVCCFLAGS+=" --gpu-architecture=compute_70 --gpu-code=sm_70,sm_75"
+#NVCCFLAGS+=" --gpu-architecture=compute_86 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_86,code=compute_86 "
+NVCCFLAGS+=" --gpu-architecture=sm_80 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_70,code=sm_70  -gencode=arch=compute_75,code=sm_75"
+#--extra-device-vectorization
+NVCCFLAGS+=" --default-stream per-thread -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
 
 AC_SUBST(CUDA_LIBS)
 AC_SUBST(CUDA_CFLAGS)

--- a/src/core/cistem_parameters.cpp
+++ b/src/core/cistem_parameters.cpp
@@ -804,7 +804,7 @@ void cisTEMParameters::WriteTocisTEMBinaryFile(wxString wanted_filename, int fir
 	if (parameters_to_write.position_in_stack == true)
 	{
 		bitmask_identifier = POSITION_IN_STACK;
-		data_type = UNSIGNED_INTEGER;
+		data_type = INTEGER_UNSIGNED;
 
 		fwrite ( &bitmask_identifier, sizeof(long), 1, cisTEM_bin_file );
 		fwrite ( &data_type, sizeof(char), 1, cisTEM_bin_file );

--- a/src/core/cistem_star_file_reader.cpp
+++ b/src/core/cistem_star_file_reader.cpp
@@ -1597,7 +1597,7 @@ bool cisTEMStarFileReader::ReadBinaryFile(wxString wanted_filename, ArrayOfcisTE
 					if (SafelyReadFromBinaryBufferIntoInteger(buffer_int) == false) return false;
 				}
 				else
-				if (column_data_types[current_column] == UNSIGNED_INTEGER)
+				if (column_data_types[current_column] == INTEGER_UNSIGNED)
 				{
 					unsigned int buffer_int;
 					if (SafelyReadFromBinaryBufferIntoUnsignedInteger(buffer_int) == false) return false;

--- a/src/core/defines.h
+++ b/src/core/defines.h
@@ -22,7 +22,7 @@
 #define DOUBLE      	 6
 #define CHAR			 7
 #define VARIABLE_LENGTH  8
-#define UNSIGNED_INTEGER 9
+#define INTEGER_UNSIGNED 9
 
 
 // From Table 2.2 DeGraff

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -176,7 +176,7 @@ public:
 	void CircleMaskWithValue(float wanted_mask_radius, float wanted_mask_value, bool invert = false);
 	void SquareMaskWithValue(float wanted_mask_dim, float wanted_mask_value, bool invert = false, int wanted_center_x = 0, int wanted_center_y = 0, int wanted_center_z = 0);
 	void TriangleMask(float wanted_triangle_half_base_length);
-	void CalculateCTFImage(CTF &ctf_of_image, bool calculate_complex_ctf = false);
+	void CalculateCTFImage(CTF &ctf_of_image, bool calculate_complex_ctf = false, bool apply_coherence_envelope = false);
 	void CalculateBeamTiltImage(CTF &ctf_of_image, bool output_phase_shifts = false);
 	bool ContainsBlankEdges(float mask_radius = 0.0);
 	void CorrectMagnificationDistortion(float distortion_angle, float distortion_major_axis, float distortion_minor_axis);
@@ -407,7 +407,8 @@ public:
 	void ComputeFilteredAmplitudeSpectrumFull2D(Image* average_spectrum_masked, Image* current_power_spectrum, float& average, float& sigma, float minimum_resolution, float maximum_resolution, float pixel_size_for_fitting);
 	void ComputeAmplitudeSpectrum(Image *other_image, bool signed_values = false);
 	void ComputeHistogramOfRealValuesCurve(Curve *histogram_curve);
-	void Compute1DPowerSpectrumCurve(Curve *curve_with_average_power, Curve *curve_with_number_of_values);
+	void Compute1DAmplitudeSpectrumCurve(Curve *curve_with_average_power, Curve *curve_with_number_of_values);
+	void Compute1DPowerSpectrumCurve(Curve *curve_with_average_power, Curve *curve_with_number_of_values, bool average_amplitudes_not_intensities = false);
 	void Compute1DRotationalAverage(Curve &average, Curve &number_of_values, bool fractional_radius_in_real_space = false, bool average_real_parts = false);
 	void ComputeSpatialFrequencyAtEveryVoxel();
 	void AverageRadially();

--- a/src/gpu/GpuImage.h
+++ b/src/gpu/GpuImage.h
@@ -9,6 +9,7 @@
 #define GPUIMAGE_H_
 
 
+
 class GpuImage {
 
 public:
@@ -150,7 +151,7 @@ public:
 	void ForwardFFT(bool should_scale = true);                                           /**CPU_eq**/
 	void BackwardFFT();                                                                   /**CPU_eq**/
 	void ForwardFFTAndClipInto(GpuImage &image_to_insert, bool should_scale);
-	template < typename T > void BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_half_precision = false);
+	template < typename T > void BackwardFFTAfterComplexConjMul(T* image_to_multiply, bool load_half_precision);
 
 
 	float ReturnSumOfSquares();
@@ -201,13 +202,13 @@ public:
 					   input_dims.z);
 	};
 
-	__inline__  void ReturnLaunchParamtersLimitSMs(int N, int M)
+	__inline__  void ReturnLaunchParamtersLimitSMs(float N, int M)
 	{
 		// This should only be called for kernels with grid stride loops setup. The idea
 		// is to limit the number of SMs available for some kernels so that other threads on the device can run in parallel.
 		// limit_SMs_by_threads is default 1, so this must be set prior to this call.
 	  threadsPerBlock = dim3(M, 1, 1);
-	  gridDims = dim3( N* number_of_streaming_multiprocessors );
+	  gridDims = dim3( myroundint(N* number_of_streaming_multiprocessors) );
 	};
 
 	void CopyFromCpuImage(Image &cpu_image);

--- a/src/gpu/Histogram.h
+++ b/src/gpu/Histogram.h
@@ -23,14 +23,19 @@ public:
 	dim3 threadsPerBlock_accum_array;
 	dim3 gridDims_accum_array;
 
+//	float* histogram;		bool is_allocated_histogram; // histogram_n_bins in size;
 	float* histogram;		bool is_allocated_histogram; // histogram_n_bins in size;
+
 	size_t size_of_temp_hist;
 	float* cummulative_histogram;
 
 	int histogram_n_bins; //
-	float histogram_min;
-	float histogram_max;
-	float histogram_step;
+//	float histogram_min;
+//	float histogram_max;
+//	float histogram_step;
+	__half histogram_min;
+	__half histogram_max;
+	__half histogram_step;
 
 	int max_padding;
 

--- a/src/gpu/TemplateMatchingCore.h
+++ b/src/gpu/TemplateMatchingCore.h
@@ -12,15 +12,15 @@
 //
 //} Peaks;
 
-typedef
-struct __align__(8) _Peaks {
-	// This should be 128 byte words, so good for read access?
-	__half mip;
-	__half psi;
-	__half theta;
-	__half phi;
-
-} Peaks;
+//typedef
+//struct __align__(8) _Peaks {
+//	// This should be 128 byte words, so good for read access?
+//	__half mip;
+//	__half psi;
+//	__half theta;
+//	__half phi;
+//
+//} Peaks;
 //typedef
 //struct __align__(16) _Peaks {
 //	// This should be 128 byte words, so good for read access?
@@ -41,11 +41,16 @@ struct __align__(8) _Peaks {
 //	__half sum_sq_diff;
 //	int N;
 //} Stats;
-typedef
-struct __align__(8) _Stats{
-	cufftReal sum;
-	cufftReal sq_sum;
-} Stats;
+//typedef
+//struct __align__(8) _Stats{
+//	cufftReal sum;
+//	cufftReal sq_sum;
+//} Stats;
+//typedef
+//	struct __align__(4) _Stats{
+//__half sum;
+//__half sq_sum;
+//} Stats;
 
 class TemplateMatchingCore {
 
@@ -130,12 +135,13 @@ public:
 
 	MyApp *parent_pointer;
 
-	Stats* my_stats;
-	Peaks* my_peaks;
+	__half2* my_stats;
+	__half2* my_peaks;
+	__half2* my_new_peaks; // for passing euler angles to the callback
 	void SumPixelWise(GpuImage &image);
-    void MipPixelWise(GpuImage &image, __half psi, __half theta, __half phi);
-	void MipToImage(const Peaks* my_peaks, GpuImage &mip, GpuImage &psi, GpuImage &theta, GpuImage &phi);
-	void AccumulateSums(Stats* my_stats, GpuImage &sum, GpuImage &sq_sum);
+    void MipPixelWise( __half psi, __half theta, __half phi);
+	void MipToImage();
+	void AccumulateSums(__half2* my_stats, GpuImage &sum, GpuImage &sq_sum);
 
 
 	void Init(MyApp *parent_pointer,

--- a/src/gui/MatchTemplatePanel.cpp
+++ b/src/gui/MatchTemplatePanel.cpp
@@ -483,6 +483,7 @@ void MatchTemplatePanel::StartEstimationClick( wxCommandEvent& event )
 	int number_of_pixel_size_positions;
 
 	bool use_gpu;
+	int  max_threads = 1; // Only used for the GPU code. For GUI this comes from the run profile -> command line override as in other programs.
 
 	int image_number_for_gui;
 	int number_of_jobs_per_image_in_gui;
@@ -785,7 +786,7 @@ void MatchTemplatePanel::StartEstimationClick( wxCommandEvent& event )
 			//wxPrintf("%i = %i - %i\n", job_counter, first_search_position, last_search_position);
 
 
-			current_job_package.AddJob("ttffffffffffifffffbfftttttttttftiiiitttfb",	input_search_image.ToUTF8().data(),
+			current_job_package.AddJob("ttffffffffffifffffbfftttttttttftiiiitttfbi",	input_search_image.ToUTF8().data(),
 																	input_reconstruction.ToUTF8().data(),
 																	pixel_size,
 																	voltage_kV,
@@ -825,7 +826,8 @@ void MatchTemplatePanel::StartEstimationClick( wxCommandEvent& event )
 																	directory_for_results.ToUTF8().data(),
 																	output_result_file.ToUTF8().data(),
 																	min_peak_radius,
-																	use_gpu);
+																	use_gpu,
+																	max_threads);
 		}
 
 		delete current_image_euler_search;

--- a/src/programs/make_template_result/make_template_result.cpp
+++ b/src/programs/make_template_result/make_template_result.cpp
@@ -194,7 +194,7 @@ bool MakeTemplateResult::DoCalculation()
 	if (ignore_N_pixels_from_the_border < 0)
 	{
 		// Default value is -1 giving
-		ignore_N_pixels_from_the_border = input_reconstruction_file.ReturnXSize() / 2 + 1;
+		ignore_N_pixels_from_the_border = input_reconstruction_file.ReturnXSize() / 4 + 1;
 		// Otherwise, the user has asked for a specific value. Only available from the CLI.
 	}
 


### PR DESCRIPTION
The main features are acceleration via half-precision floats, and a few small tweaks in the gpu code to get to 10.5x socket to socket speed up.

There are also some bug fixes & changes for consistency in the peak search with template matching code.

See issue #287 

The option to calculate the average of Fourier amplitudes not intensities was added for Guinier analysis I used in trouble shooting for this paper, and I figured it may be useful if we were to want to do Guinier plots in the future.


cisTEMParameters & cistem_star_file_reader & defines.h	
        *Change UNSIGNED_INTEGER to INTEGER_UNSIGNED see issue #287

Image::CalculateCtfImage

	*Add option to apply the CTF coherence envelope. Default false.'

Image::Compute1DPowerSpectrumCurve
	*Add option to average amplitudes not intensities for Guinier analysis
		bool average_amplitudes_not_intensities

make_template_result/ match_template

	*Change default edge exclusion radius to 1/4 box size, rather than 1/2. Box should be padded to 2x particle radius meaning a full particle (less delocalized info) is still in the image with only 1/4 excluded.
	*Note that in match_template it was hardcoded to 50 pixels

match_template

	*Change the range of the stored histogram to better match realistic outputs
	*Enable symmetry from CLI
	*Enable number of threads to be specified, which is important for saturating the GPU, especially for smaller images. (CLI and GUI)
	*variable temp_threshold now initialized to 1.0. This only matters when compiled w/o MKL
	*Fix threshold calc
	*Edge pixels to ignore was hardcoded to 50, change to box_size/4 to match new default in make_template_results

gui/MatchTemplatePanel

	*Changes to take threads from runprofile and pass to match_template

ax_cuda.m4

	*Add compatibility with Ampere arch

src/gpu

	*Changes to core functions to work with half-precision values to accelerate template matching further.