### PR TITLE
Abinitio nan fixes

### DIFF
--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -491,6 +491,8 @@ float Image::GetWeightedCorrelationWithImage(Image &projection_image, int *bins,
 //	MyDebugAssertTrue(! projection_image.object_is_centred_in_box, "projection_image quadrants have not been swapped");
 	MyDebugAssertTrue(HasSameDimensionsAs(&projection_image), "Images do not have the same dimensions");
 	MyDebugAssertTrue(bins != NULL, , "bin_index not calculated");
+	MyDebugAssertFalse(HasNan(), "Image has one or more NaN pixels");
+	MyDebugAssertFalse(projection_image.HasNan(),"Projection has one or more NaN pixels");
 
 	int i;
 //	int j;

--- a/src/core/resolution_statistics.cpp
+++ b/src/core/resolution_statistics.cpp
@@ -685,9 +685,11 @@ void ResolutionStatistics::RestrainParticleSSNR(float low_resolution_limit)
     {
     	if (temp_curve.data_x[i] >= reciprocal_resolution_limit)
     	{
-    		if (adjustment_factor < -FLT_MAX / 2.0f) adjustment_factor = part_SSNR.data_y[i] / powf(temp_curve.gaussian_fit[i], 2);
+			// Set adjustment factor for the first time
+    		if (adjustment_factor < -FLT_MAX * 0.5f && temp_curve.gaussian_fit[i] > 0.0f) adjustment_factor = part_SSNR.data_y[i] / powf(temp_curve.gaussian_fit[i], 2);
     		// Square Gaussian for additional down-weighting of high frequencies to counter over-fitting
-    		part_SSNR.data_y[i] = adjustment_factor * powf(temp_curve.gaussian_fit[i], 2);
+			// Only do this if adjustment_factor was set to a reasonable value
+    		if (adjustment_factor >= -FLT_MAX * 0.5f) part_SSNR.data_y[i] = adjustment_factor * powf(temp_curve.gaussian_fit[i], 2);
     	}
     }
 }

--- a/src/programs/refine3d/refine3d.cpp
+++ b/src/programs/refine3d/refine3d.cpp
@@ -207,8 +207,7 @@ float FrealignObjectiveFunction(void *scoring_parameters, float *array_of_values
 #endif
 
 
-	return 	- tmp_corr
-			- tmp_penalty;
+	return 	- tmp_corr - tmp_penalty;
 		// This penalty term assumes a Gaussian x,y distribution that is probably not correct in most cases. It might be better to leave it out.
 }
 


### PR DESCRIPTION
This addresses two separate bugs, both of which were causing ab initio to crash.

[Bug 1] It looks like the gradient minimizer `va04` occasionally tries `NaN` x/y shits parameter values. This in turn would cause the image to turn to `NaN` because of the phase shift. Rather than trying to fix `va04`, which shall remain a black box for now, the scoring function now checks for `NaN` and returns a terrible score if there is one.

[Bug 2] This one was more tricky. The function `ResolutionStatistics::RestrainParticleSSNR` is used to tweak the SSNR-based filter that is applied to the particle image just before refinement. Under specific circumstances, I think during the first cycle after ab initio started reconstructing to higher resolution (from ~ 11 Å to ~ 10 Å) and with a finer pixel size, the incoming FSC curve is good until the old Nyquist, but then falls off abruptly to 0.0 at ~ 10 Å. Turns out, `RestrainParticleSSNR` does a Gaussian fit to the incoming SSNR curve, starting at 10 Å, and then does a division by the fit value to derive a scaling factor. In this particular circumstance, the SSNR is = 0.0 at 10 Å and beyond, so this led to a division by 0. The commit bf2a61fd7a5ce1d85ce93cf5f16065cc54c6f605 circumvents this by checking whether the Gaussian fit value is > 0.