### PR TITLE
Refine template and make stack

### DIFF
--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -90,6 +90,8 @@ if test "$want_cuda" = "yes" ; then
 	# test if nvcc version is >= 2.3
 	NVCC_VERSION=`$NVCC --version | grep release | awk 'gsub(/,/, "") {print [$]5}'`
 	AC_MSG_RESULT([nvcc version : $NVCC_VERSION $NVCC_VERSION])
+  # I don't like relying on parsing strings, but this works fine for cuda 8-11.3
+  is_cuda_ge_11=`echo $NVCC_VERSION | awk '{if([$]1 < 11.0) print 0 ; else print 1}'`
 	
  	# we'll only use 64 bit arch
   	libdir=lib64
@@ -247,9 +249,13 @@ else
 		
 fi
 
- 
+if test "x$is_cuda_ge_11" -eq "1" ; then
+  AC_MSG_NOTICE([CUDA >= 11.0, enabling --extra-device-vectorization])
+  NVCCFLAGS+=" --extra-device-vectorization"
+fi
+  
 #--extra-device-vectorization
-NVCCFLAGS+=" --default-stream per-thread --extra-device-vectorization -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
+NVCCFLAGS+=" --default-stream per-thread -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -std=c++11 -Xcompiler= -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
 
 AC_ARG_ENABLE(gpu-cache-hints, AS_HELP_STRING([--disable-gpu-cache-hints],[Do not use the intrinsics for cache hints]),[
   if test "$enableval" = no; then

--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -45,30 +45,32 @@
 AC_DEFUN([AX_CUDA],
 [
 
-AC_ARG_WITH([cuda],
-    AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix where cuda is installed (default=yes)]),
+# Default install for cuda
+default_cuda_home_path="/usr/local/cuda"
+
+# In Thrust 1.10 c++11 is deprecated. Not using those libs now, so squash warnings, but we should consider switching to a newer standard
+AC_DEFINE(THRUST_IGNORE_DEPRECATED_CPP_11,true)
+
+AC_MSG_NOTICE([Checking for gpu request and vars])
+AC_ARG_WITH([cuda], AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix where cuda is installed (default=no)]),
 [
 	with_cuda=$withval
-  cuda_home_path="/usr/local/cuda"
-	if test "$withval" = "no"
-	then
-		want_cuda="no"
-	elif test "$withval" = "yes"
-	then
+	if test "$withval" = "yes" ; then
 		want_cuda="yes"
-	else
-		want_cuda="yes"
-		cuda_home_path=$withval
+		cuda_home_path=$default_cuda_home_path
+	else 
+		if test "$withval" = "no" ; then
+			want_cuda="no"
+		else
+			want_cuda="yes"
+			cuda_home_path=$withval
+		fi
 	fi
-],
-[
-	want_cuda="no"
-])
+	
+], [ want_cuda="no"] )
 
+if test "$want_cuda" = "yes" ; then
 
-
-if test "$want_cuda" = "yes"
-then
 	# check that nvcc compiler is in the path
 	if test -n "$cuda_home_path"
 	then
@@ -89,23 +91,23 @@ then
 	NVCC_VERSION=`$NVCC --version | grep release | awk 'gsub(/,/, "") {print [$]5}'`
 	AC_MSG_RESULT([nvcc version : $NVCC_VERSION $NVCC_VERSION])
 	
-  # we'll only use 64 bit arch
-  libdir=lib64
+ 	# we'll only use 64 bit arch
+  	libdir=lib64
 
-	# set CUDA flags
+	# set CUDA flags for static compilation. This is required for cufft callbacks.
 	if test -n "$cuda_home_path"
 	then
-	    CUDA_CFLAGS="-I$cuda_home_path/include  -I$cuda_home_path/samples/common/inc/"
+	  CUDA_CFLAGS="-I$cuda_home_path/include  -I$cuda_home_path/samples/common/inc/"
       CUDA_LIBS="-L$cuda_home_path/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lcurand_static -lculibos -lcudart_static -lrt"
 	else
-	    CUDA_CFLAGS="-I/usr/local/cuda/include  -I/usr/local/cuda/samples/common/inc/"
-	    CUDA_LIBS="-L/usr/local/cuda/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lcurand_static -lculibos -lcudart_static -lrt"
+	  CUDA_CFLAGS="-I/usr/local/cuda/include  -I/usr/local/cuda/samples/common/inc/"
+	  CUDA_LIBS="-L/usr/local/cuda/$libdir -lcufft_static -lnppial_static -lnppist_static -lnppc_static -lcurand_static -lculibos -lcudart_static -lrt"
 	fi
 
 
 	saved_CPPFLAGS=$CPPFLAGS
 	saved_LIBS=$LIBS
-  saved_CUDA_LIBS=$CUDA_LIBS
+  	saved_CUDA_LIBS=$CUDA_LIBS
 
 	# Env var CUDA_DRIVER_LIB_PATH can be used to set an alternate driver library path
 	# this is usefull when building on a host where only toolkit (nvcc) is installed
@@ -122,7 +124,7 @@ then
 
 	AC_LANG_PUSH(C)
 	AC_MSG_CHECKING([for Cuda headers])
-  AC_MSG_NOTICE([cuda path is $cuda_home_path])
+  	AC_MSG_NOTICE([cuda path is $cuda_home_path])
 	AC_COMPILE_IFELSE(
 	[
 		AC_LANG_PROGRAM([@%:@include <cuda.h>], [])
@@ -166,7 +168,7 @@ then
 
 	CPPFLAGS=$saved_CPPFLAGS
 	LIBS=$saved_LIBS
-  CUDA_LIBS=$saved_CUDA_LIBS
+  	CUDA_LIBS=$saved_CUDA_LIBS
 	
 	if test "$have_cuda_headers" = "yes" -a "$have_cuda_libs" = "yes" -a "$have_nvcc" = "yes"
 	then
@@ -177,55 +179,84 @@ then
 	fi
 fi
 
-#AC_SUBST(CUDA_CFLAGS)
-#AC_SUBST(CUDA_LIBS)
-#AC_SUBST(NVCC)
-
-# This is set to default by BAH
-want_fast_math="yes"
-AC_ARG_WITH([cuda-fast-math],
-	[AC_HELP_STRING([--with-cuda-fast-math],
-		[Tell nvcc to use -use_fast_math flag])],
-	[
-		if test "$withval" = "no"
-		then
-			want_fast_math="no"
-		elif test "$withval" = "yes"
-		then
-			want_fast_math="yes"
-		else
-			with_fast_math="$withval"
-			want_fast_math="yes"
-		fi
-	 ],
-         [
-		want_fast_math="yes"
-	 ]
-)
-
+# This is the code that will be generated at compile time and should be specified for the most used gpu 
+target_arch=""
+AC_ARG_WITH([target-gpu-arch], AS_HELP_STRING([--with-target-gpu-arch@<:@=60,61,70,75,80,86@:>@], [Primary architecture to compile for (default=86)]),
+[
+	if test "$withval" = "86" ; then target_arch=86 
+	elif  test "$withval" = "80" ; then target_arch=80
+	elif  test "$withval" = "75" ; then target_arch=75
+	elif  test "$withval" = "70" ; then target_arch=70
+	elif  test "$withval" = "61" ; then target_arch=61
+	elif  test "$withval" = "60" ; then target_arch=60
+	else
+		AC_MSG_ERROR([Requested target-gpu-arch must be in 60,61,70,75,80,86, not $withval])
+	fi
+	
+], [ target_arch="86"] )
+AC_MSG_NOTICE([target gpu architecture is sm$target_arch])
 
 # Default nvcc flags
-
 NVCCFLAGS=" -ccbin $CXX"
-#AC_ARG_ENABLE([emu],
-#    AS_HELP_STRING([--enable-emu], [Turn on device emulation for CUDA]),
-#    [case "${enableval}" in
-#        yes) EMULATION=true ;;
-#        no)  EMULATION=false ;;
-#        *)   AC_MSG_ERROR([bad value ${enableval} for --enable-emu]) ;;
-#    esac],
-#    [EMULATION=false]
-#)
+NVCCFLAGS+=" --gpu-architecture=sm_$target_arch -gencode=arch=compute_$target_arch,code=compute_$target_arch"
 
+# This is the oldest arch that will have JIT-able code g
+oldest_arch=""
+AC_ARG_WITH([oldest-gpu-arch], AS_HELP_STRING([--with-oldest-gpu-arch@<:@=60,61,70,75,80,86:>@], [Oldest architecture make compatible for (default=70)]),
+[
+	if test "$withval" = "86" ; then oldest_arch=86 
+	elif  test "$withval" = "80" ; then oldest_arch=80
+	elif  test "$withval" = "75" ; then oldest_arch=75
+	elif  test "$withval" = "70" ; then oldest_arch=70
+	elif  test "$withval" = "61" ; then oldest_arch=61
+	elif  test "$withval" = "60" ; then oldest_arch=60
+	else
+		AC_MSG_ERROR([Requested target-oldest_arch must be in 60,61,70,75,80,86, not $withval])
+	fi
+	
+], [ oldest_arch="70"] )
+AC_MSG_NOTICE([oldest gpu architecture is sm$oldest_arch])
 
+if test "$oldest_arch" -gt "$target_arch" ; then 
+	AC_MSG_ERROR([Requested target-oldest_arch is greater than the target arch.]) 
+else
+	current_arch="60"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi
+	
+	current_arch="61"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi
+	
+	current_arch="70"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi	
+	
+	current_arch="75"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi	
+	
+	current_arch="80"
+	if test "$current_arch" -ge $oldest_arch && test "$current_arch" -lt "$target_arch" ; then
+		NVCCFLAGS+=" -gencode=arch=compute_$current_arch,code=sm_$current_arch"
+	fi		
+		
+fi
 
-# For now just compile for Volta and Turing arch
-#NVCCFLAGS+=" --gpu-architecture=compute_70 --gpu-code=sm_70,sm_75"
-#NVCCFLAGS+=" --gpu-architecture=compute_86 -gencode=arch=compute_86,code=sm_86 -gencode=arch=compute_86,code=compute_86 "
-NVCCFLAGS+=" --gpu-architecture=sm_80 -gencode=arch=compute_86,code=compute_86 -gencode=arch=compute_70,code=sm_70  -gencode=arch=compute_75,code=sm_75"
+ 
 #--extra-device-vectorization
-NVCCFLAGS+=" --default-stream per-thread -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
+NVCCFLAGS+=" --default-stream per-thread --extra-device-vectorization -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -std=c++11 -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
 
+AC_ARG_ENABLE(gpu-cache-hints, AS_HELP_STRING([--disable-gpu-cache-hints],[Do not use the intrinsics for cache hints]),[
+  if test "$enableval" = no; then
+  	NVCCFLAGS+=" -Xcompiler= -DDISABLECACHEHINTS"
+  	AC_MSG_NOTICE([Disabling cache hint intrinsics requiring CUDA 11 or newer])  	
+  fi])
+  
 AC_SUBST(CUDA_LIBS)
 AC_SUBST(CUDA_CFLAGS)
 AC_SUBST(NVCCFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -173,6 +173,15 @@ want_cuda="no"
 AX_CUDA  
   	
 if test "$want_cuda" = "yes" ; then
+
+	# ~Runtime about 85% with K3 images, but mips are different - total detection is ~the same, but needs more investigation.
+	# Disabling by default so that the code matches what Bronwyn used in the 2D vs 3DTM paper (for reproducibility.)
+	AC_ARG_ENABLE(rotated-tm, AS_HELP_STRING([--enable-rotated-tm],[Place power of 2 sized axis on X by rotating 90 deg in template matching for speed [default=no]]),[
+	  if test "$enableval" = yes; then
+	  CPPFLAGS="$CPPFLAGS -DROTATEFORSPEED"
+	  CXXFLAGS="$CXXFLAGS -DROTATEFORSPEED"
+	  fi
+	  ])
 		
     AC_MSG_NOTICE([Adding the CUDA includes Setting up NVCC initial flags])
     CUDA_CPPFLAGS="$CUDA_CFLAGS $NVCCFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -30,16 +30,36 @@ AC_MSG_NOTICE([Setting up initial flags])
 
 
 # check to see if compiler warnings are desired.
-WALLON=""
-AC_ARG_WITH([warnings-on], [Enable compiler warnings], [WALLON="-Wall"])
+
+AC_ARG_ENABLE([disable-warnings], AS_HELP_STRING([--disable compiler warnings], [Default=false]), 
+[
+	# If flag do this
+	if test "x$enableval" = "no" ; then
+		WARNINGS_ON=""		
+	else
+		if test "x$CXX" = "xicpc"; then		
+			WARNINGS_ON="-w2"
+		else
+			WARNINGS_ON="-Wall"	
+		fi		
+	fi
+], 
+[ 
+		# If no flag do this
+		if test "x$CXX" = "xicpc"; then		
+			WARNINGS_ON="-w2"
+		else
+			WARNINGS_ON="-Wall"	
+		fi	
+])
 
 
 if test "x$CXX" = "xicpc"; then		
-	CXXFLAGS="$CXXFLAGS -O3 -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11 -w2 -wd1125"
-	CPPFLAGS="$CPPFLAGS -O3 -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
+	CXXFLAGS="$CXXFLAGS -O3 -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11 -wd1125"
+	CPPFLAGS="$CPPFLAGS -O3 -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
 else
-	CXXFLAGS="$CXXFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WALLON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11"		
-	CPPFLAGS="$CPPFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WALLON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
+	CXXFLAGS="$CXXFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WARNINGS_ON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -std=c++11"		
+	CPPFLAGS="$CPPFLAGS -DNDEBUG -funroll-loops -O3 -pipe $WARNINGS_ON -fexpensive-optimizations -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
 
 	#sqlite needs dl on gcc
 	
@@ -75,28 +95,33 @@ AM_CONDITIONAL([LINUX_AM], [test "$build_linux" = "yes"])
 AM_CONDITIONAL([WINDOWS_AM], [test "$build_windows" = "yes"])
 AM_CONDITIONAL([OSX_AM], [test "$build_mac" = "yes"])
 
-# Use all available processor instruction sets
-AC_ARG_ENABLE(latest-instruction-set, [  --enable-latest-instruction-set     Use latest available CPU instruction set [[default=yes]]],[
+# Use all available processor instruction sets - this defaults to no (I think) if the option is not flagged. See issue #296 on github
+instruction_set=""
+AC_ARG_ENABLE(latest-instruction-set, AS_HELP_STRING([--enable-latest-instruction-set],[Use the latest available CPU instruction set, only affects Intel compiler [default=no]]),[
   if test "$enableval" = yes; then
-	if test "x$CXX" = "xicpc"; then	
-		CXXFLAGS="$CXXFLAGS -xHost"
-	fi
+	instruction_set=" -xHost -wd10382"
   fi
-  ])
+]) #, [instruction_set=" -xHost -wd10382"]) if we wanted default to be yes, this fourth arg should be included.
+
+if test "x$CXX" = "xicpc"; then	
+	CXXFLAGS="$CXXFLAGS $instruction_set"
+fi
 
 # MKL
 
-AC_ARG_ENABLE(mkl, [  --disable-mkl           Do not use the Intel MKL ],[
-  if test "$enableval" = no; then
+use_mkl=1
+AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]),
+[
+ if test "$enableval" = no; then
         use_mkl=0
-  fi])
+ fi
+ ])
 
 
 # Static linking
 
 static_link="false"
-
-AC_ARG_ENABLE(staticmode, [  --enable-staticmode     Link statically [[default=no]]],[
+AC_ARG_ENABLE(staticmode, AS_HELP_STRING([--enable-staticmode],[Link statically [default=no]]),[
   if test "$enableval" = yes; then
 	static_link="true"
 	WXCONFIGFLAGS="--static=yes"
@@ -112,73 +137,48 @@ AM_CONDITIONAL([STATIC_LINKING_AM],[test x$static_link = xtrue])
 
 WXCONFIG=wx-config
 AC_ARG_WITH(wx-config,
-[[  --with-wx-config=FILE   Use the given path to wx-config when determining
-                          wxWidgets configuration; defaults to "wx-config"]],
+AS_HELP_STRING([--with-wx-config=FILE],[Use the given path to wx-config when determining
+                          wxWidgets configuration; defaults to "wx-config"]),
 [
     if test "$withval" != "yes" -a "$withval" != ""; then
         WXCONFIG=$withval
     fi
 ])
 
-# MKL
 
-use_mkl=1
 
-AC_ARG_ENABLE(mkl, [  --disable-mkl           Do not use the Intel MKL ],[
-  if test "$enableval" = no; then
-  	use_mkl=0
-  fi])
+
 
 # debugmode
 
-AC_ARG_ENABLE(debugmode, [  --enable-debugmode      Compile in debug mode [[default=no]]],[
+AC_ARG_ENABLE(debugmode, AS_HELP_STRING([--enable-debugmode],[Compile in debug mode [default=no]]),
+[
   if test "$enableval" = yes; then
   if test "x$CXX" = "xicpc"; then   
-    CXXFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 -w2 -wd1125"
-    CPPFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG"
+    CXXFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 -wd1125"
+    CPPFLAGS="-O2 -debug -no-prec-div -no-prec-sqrt $WARNINGS_ON -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG"
   else
-    CPPFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG $WALLON $INPUT_CPPFLAGS"
-    CXXFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 $WALLON $INPUT_CXXFLAGS"
+    CPPFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG $WARNINGS_ON $INPUT_CPPFLAGS"
+    CXXFLAGS="-O2 -g -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DDEBUG -std=c++11 $WARNINGS_ON $INPUT_CXXFLAGS"
   fi
   fi
-  ])
+ ])
   
-want_cuda="no"
+
 ###############################
 # BEGIN CUDA CHECKS AND SETS
 ###############################
-cuda_home_path="/usr/local/cuda"
-AC_MSG_NOTICE([Checking for gpu request and vars])
-AC_ARG_WITH([cuda], AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix where cuda is installed (default=no)]),
-[
-	with_cuda=$withval
-	if test "$withval" = "no"
-	then
-		want_cuda="no"
-	elif test "$withval" = "yes"
-	then
-		want_cuda="yes"
-	else
-		want_cuda="yes"
-		cuda_home_path=$withval
-	fi
-], [ want_cuda="no"] )
+want_cuda="no"
 
-
-if test "$want_cuda" = "yes" 
-then
-
-	# In Thrust 1.10 c++11 is deprecated. Not using those libs now, so squash warnings, but we should consider switching to a newer standard
-	AC_DEFINE(THRUST_IGNORE_DEPRECATED_CPP_11,true)
-
-	# Set conditional and run macro	
-	AX_CUDA
-	
+AX_CUDA  
+  	
+if test "$want_cuda" = "yes" ; then
+		
     AC_MSG_NOTICE([Adding the CUDA includes Setting up NVCC initial flags])
     CUDA_CPPFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
     CUDA_CXXFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
-    CXXFLAGS="$CXXFLAGS -DENABLEGPU $CUDA_CFLAGS"
-    CPPFLAGS="$CPPFLAGS -DENABLEGPU $CUDA_CFLAGS"
+    CXXFLAGS="$CXXFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
+    CPPFLAGS="$CPPFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
     AC_MSG_NOTICE([Using CUDA_CXXFLAGS=$CUDA_CXXFLAGS])
     AC_MSG_NOTICE([Using CUDA_LIBS=$CUDA_LIBS])
 fi
@@ -192,8 +192,8 @@ AM_CONDITIONAL([ENABLEGPU_AM], [test "$want_cuda" = "yes"])
 # fftw
 
 AC_ARG_WITH(fftw-dir,
-[[  --with-fftw-dir=DIR     Declare the root directory of fftw3, if its 
-                          current location is not system accessible ]],
+AS_HELP_STRING([--with-fftw-dir=DIR],[Declare the root directory of fftw3, if its 
+                          current location is not system accessible ]),
 [
     if test "$withval" != "yes" -a "$withval" != ""; then
         CPPFLAGS="$CPPFLAGS -I$withval/include -L$withval/lib"
@@ -204,7 +204,7 @@ AC_ARG_WITH(fftw-dir,
 
 # experimental
 
-AC_ARG_ENABLE(experimental, [  --enable-experimental  Compile with experimental [[default=no]]],[
+AC_ARG_ENABLE(experimental, AS_HELP_STRING([--enable-experimental],[Compile with experimental [default=no]]),[
   if test "$enableval" = yes; then
   CPPFLAGS="$CPPFLAGS -DEXPERIMENTAL"
   CXXFLAGS="$CXXFLAGS -DEXPERIMENTAL"
@@ -214,7 +214,7 @@ AC_ARG_ENABLE(experimental, [  --enable-experimental  Compile with experimental 
  
 #rigorous socket check 
 
-AC_ARG_ENABLE(rigorous-sockets, [  --enable-rigorous-sockets  Use rigorous socket checking [[default=no]]],[
+AC_ARG_ENABLE(rigorous-sockets, AS_HELP_STRING([--enable-rigorous-sockets],[Use rigorous socket checking [default=no]]),[
   if test "$enableval" = yes; then
   CPPFLAGS="$CPPFLAGS -DRIGOROUS_SOCKET_CHECK"
   CXXFLAGS="$CXXFLAGS -DRIGOROUS_SOCKET_CHECK"  
@@ -224,7 +224,7 @@ AC_ARG_ENABLE(rigorous-sockets, [  --enable-rigorous-sockets  Use rigorous socke
 AM_CONDITIONAL([EXPERIMENTAL_AM],[test x$compile_experimental = xtrue])
 
 # OpenMP
-AC_ARG_ENABLE(openmp, [  --enable-openmp  Compile with OpenMP threading [[default=no]]],[
+AC_ARG_ENABLE(openmp, AS_HELP_STRING([--enable-openmp],[Compile with OpenMP threading [default=no]]),[
   if test "$enableval" = yes; then
   AC_OPENMP([],AC_MSG_ERROR("You asked for OpenMP, but I was not able to figure out how to compile programs that use OpenMP"))
   CXXFLAGS="$CXXFLAGS $OPENMP_CXXFLAGS"

--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -593,7 +593,7 @@ float Image::GetWeightedCorrelationWithImage(Image &projection_image, int *bins,
 			}
 			else
 			{
-				sum3 += fabs(cross_terms[i]);
+				sum3 += fabsf(cross_terms[i]);
 //				wxPrintf("i_u = %i, sum_a = %g, sum_b = %i, cross = %g\n", i, sum_a[i], sum_b[i], cross_terms[i]);
 //				r = fabsf(cross_terms[i] / sqrtf(sum_b[i]));
 			}
@@ -1843,7 +1843,6 @@ void Image::RotateQuadrants(Image &rotated_image, int quad_i)
 	MyDebugAssertTrue(logical_z_dimension == 1, "Error: attempting to rotate from 3D image");
 	MyDebugAssertTrue(rotated_image.is_in_memory, "Memory not allocated for receiving image");
 //	MyDebugAssertTrue(! is_in_real_space, "Image is in real space");
-	// These next two are redundant, right? Does it matter for the real space if it is square?
 	MyDebugAssertTrue(IsSquare(), "Image to rotate is not square");
 	MyDebugAssertTrue(rotated_image.logical_x_dimension == logical_x_dimension && rotated_image.logical_y_dimension == logical_y_dimension, "Error: Images different sizes");
 	MyDebugAssertTrue(quad_i == 0 || quad_i == 90 || quad_i == 180 || quad_i == 270, "Selected rotation invalid");
@@ -4017,7 +4016,7 @@ float Image::CosineMask(float wanted_mask_radius, float wanted_mask_edge, bool i
 			pixel_sum /= number_of_pixels;
 		}
 
-		pixel_counter = 0.0;
+		pixel_counter = 0;
 		for (k = 0; k < logical_z_dimension; k++)
 		{
 			z = powf(k - physical_address_of_box_center_z, 2);

--- a/src/core/particle.cpp
+++ b/src/core/particle.cpp
@@ -909,12 +909,16 @@ float Particle::ReturnLogLikelihood(Image &input_image, CTF &input_ctf, Reconstr
 //	particle_image->QuickAndDirtyWriteSlice("diff.mrc", 1);
 	// This low-pass filter reduces the number of independent pixels. It should therefore be applied only to
 	// the reference (temp_projection), and not to the difference (temp_particle - temp_projection), as is done here...
-	if (classification_resolution_limit > 0.0)
+//	temp_particle->ForwardFFT();
+//	if (classification_resolution_limit < 20.0f) temp_particle->CosineMask(original_pixel_size / 20.0f, original_pixel_size / 10.0f, true);
+	if (classification_resolution_limit > 0.0f)
 	{
 		temp_particle->ForwardFFT();
 		temp_particle->CosineMask(original_pixel_size / classification_resolution_limit, original_pixel_size / mask_falloff);
+//		temp_particle->CosineMask(0.75f * original_pixel_size / classification_resolution_limit, original_pixel_size / classification_resolution_limit);
 		temp_particle->BackwardFFT();
 	}
+//	temp_particle->BackwardFFT();
 	if (apply_2D_masking)
 	{
 		variance_difference = temp_particle->ReturnSumOfSquares(pixel_radius_2d, rotated_center_x + temp_particle->physical_address_of_box_center_x,

--- a/src/core/pdb.cpp
+++ b/src/core/pdb.cpp
@@ -267,7 +267,6 @@ void PDB::SetEmpty()
 		this->center_of_mass[2] = 0;
 	}
 
-
 }
 
 void PDB::Init()

--- a/src/core/pdb.h
+++ b/src/core/pdb.h
@@ -105,7 +105,6 @@ class PDB {
 		~PDB();
 
 		// data
-
 		long number_of_lines;
 		long number_of_atoms; // total atoms to simulate, active in this particle
 		long number_of_real_and_noise_atoms; // total atoms in the PDB object

--- a/src/core/water.cpp
+++ b/src/core/water.cpp
@@ -114,7 +114,6 @@ void Water::Init(const PDB *current_specimen, int wanted_size_neighborhood, floa
 //		}
 
 		wxPrintf("size post rot 2 padding %d %d padX %d padY %d padZ %d rot\n",vol_nX, vol_nY, *padX, *padY, padZ);
-
 		MyAssertTrue(current_specimen->pixel_size > 0.0f, "The pixel size for your PDB object is not yet set.");
 		// Copy over some values from the current specimen - Do these need to be updated for tilts and rotations?
 		this->vol_angX = vol_nX * current_specimen->pixel_size; //current_specimen->vol_angX;

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -71,8 +71,11 @@ __device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal elemen
 //	data_out_half[offset] = __float2half(element);
 //	((cufftReal *)dataOut)[offset] = element;
 
-   __stcs( &data_out_half[offset], __float2half(element) );
-//	((__half *)dataOut)[offset] = __float2half(element);
+#ifdef DISABLECACHEHINTS
+	((__half *)dataOut)[offset] = __float2half(element);
+#else
+	__stcs( &data_out_half[offset], __float2half(element) );
+#endif
 
 //	)_(dataOut)[offset] = __float2half(element);
 //

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -72,7 +72,7 @@ __device__ void CB_mipCCGAndStore(void* dataOut, size_t offset, cufftReal elemen
 //	((cufftReal *)dataOut)[offset] = element;
 
 #ifdef DISABLECACHEHINTS
-	((__half *)dataOut)[offset] = __float2half(element);
+	((__half *)data_out_half)[offset] = __float2half(element);
 #else
 	__stcs( &data_out_half[offset], __float2half(element) );
 #endif

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -2,7 +2,7 @@
 
 
 // Values for data that are passed around in the results.
-const int number_of_output_images = 8; //mip, scaledmip, psi, theta, phi, pixel, defocus, sums, sqsums
+const int number_of_output_images = 8; //mip, psi, theta, phi, pixel, defocus, sums, sqsums (scaled mip is not sent out)
 const int number_of_meta_data_values = 6; // img_x, img_y, number cccs, histogram values.
 const int MAX_ALLOWED_NUMBER_OF_PEAKS = 1000; // An error will be thrown and job aborted if this number of peaks is exceeded in the make template results block
 
@@ -1186,6 +1186,8 @@ bool MatchTemplateApp::DoCalculation()
 		max_intensity_projection.Rotate2DInPlaceBy90Degrees(false);
 
 		best_psi.Rotate2DInPlaceBy90Degrees(false);
+		// To account for the pre-rotation, psi needs to have 90 added to it.
+		best_psi.AddConstant(90.0f);
 		best_theta.Rotate2DInPlaceBy90Degrees(false);
 		best_phi.Rotate2DInPlaceBy90Degrees(false);
 		best_defocus.Rotate2DInPlaceBy90Degrees(false);

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -586,6 +586,7 @@ bool MatchTemplateApp::DoCalculation()
 
 
 	input_image.Resize(factorizable_x, factorizable_y, 1, input_image.ReturnAverageOfRealValuesOnEdges());
+#ifdef ROTATEFORSPEED
 	if ( ! is_power_of_two(factorizable_x) && is_power_of_two(factorizable_y) )
 	{
 		// The speedup in the FFT for better factorization is also dependent on the dimension. The full transform (in cufft anyway) is faster if the best dimension is on X.
@@ -594,6 +595,7 @@ bool MatchTemplateApp::DoCalculation()
 		is_rotated_by_90 = true;
 		input_image.Rotate2DInPlaceBy90Degrees(true);
 	}
+#endif
 
 	}
 	padded_reference.Allocate(input_image.logical_x_dimension, input_image.logical_y_dimension, 1);

--- a/src/programs/project3d/project3d.cpp
+++ b/src/programs/project3d/project3d.cpp
@@ -48,7 +48,7 @@ void Project3DApp::DoInteractiveUserInput()
 	ouput_projection_stack = my_input->GetFilenameFromUser("Output projection stack", "The output image stack, containing the 2D projections", "my_projection_stack.mrc", false);
 	first_particle = my_input->GetIntFromUser("First particle to project (0 = first in list)", "The first particle in the stack for which a projection should be calculated", "1", 0);
 	last_particle = my_input->GetIntFromUser("Last particle to project (0 = last in list)", "The last particle in the stack for which a projection should be calculated", "0", 0);
-	pixel_size = my_input->GetFloatFromUser("Pixel size of images (A)", "Pixel size of input images in Angstroms", "1.0", 0.0);
+	pixel_size = my_input->GetFloatFromUser("Pixel size of reconstruction (A)", "Pixel size of input reconstruction in Angstroms", "1.0", 0.0);
 //	voltage_kV = my_input->GetFloatFromUser("Beam energy (keV)", "The energy of the electron beam used to image the sample in kilo electron volts", "300.0", 0.0);
 //	spherical_aberration_mm = my_input->GetFloatFromUser("Spherical aberration (mm)", "Spherical aberration of the objective lens in millimeters", "2.7", 0.0);
 //	amplitude_contrast = my_input->GetFloatFromUser("Amplitude contrast", "Assumed amplitude contrast", "0.07", 0.0, 1.0);
@@ -217,7 +217,7 @@ bool Project3DApp::DoCalculation()
 		projection_image.SwapRealSpaceQuadrants();
 
 		projection_image.BackwardFFT();
-		projection_image.ChangePixelSize(&final_image, pixel_size / input_parameters.pixel_size, 0.001f);
+		projection_image.ChangePixelSize(&final_image, input_parameters.pixel_size / pixel_size, 0.001f);
 
 		if (add_noise && wanted_SNR != 0.0)
 		{

--- a/src/programs/refine2d/refine2d.cpp
+++ b/src/programs/refine2d/refine2d.cpp
@@ -965,7 +965,7 @@ bool Refine2DApp::DoCalculation()
 		}
 		else
 		{
-			input_parameters.best_2d_class = abs(input_parameters.best_2d_class);
+			input_parameters.best_2d_class = fabsf(input_parameters.best_2d_class);
 		}
 		input_image_local.ChangePixelSize(&input_image_local, pixel_size / input_parameters.pixel_size, 0.001f);
 

--- a/src/programs/refine3d/refine3d.cpp
+++ b/src/programs/refine3d/refine3d.cpp
@@ -301,7 +301,7 @@ void Refine3DApp::DoInteractiveUserInput()
 	mask_radius_search = my_input->GetFloatFromUser("Mask radius for global search (A) (0.0 = max)", "Radius of a circular mask to be applied to the input images during global search", "100.0", 0.0);
 	high_resolution_limit_search = my_input->GetFloatFromUser("Approx. resolution limit for search (A)", "High resolution limit of the data used in the global search in Angstroms", "20.0", 0.0);
 	angular_step = my_input->GetFloatFromUser("Angular step (0.0 = set automatically)", "Angular step size for global grid search", "0.0", 0.0);
-	best_parameters_to_keep = my_input->GetIntFromUser("Number of top hits to refine", "The number of best global search orientations to refine locally", "20");
+	best_parameters_to_keep = my_input->GetIntFromUser("Number of top hits to refine", "The number of best global search orientations to refine locally", "20", 1);
 	max_search_x = my_input->GetFloatFromUser("Search range in X (A) (0.0 = 0.5 * mask radius)", "The maximum global peak search distance along X from the particle box center", "0.0", 0.0);
 	max_search_y = my_input->GetFloatFromUser("Search range in Y (A) (0.0 = 0.5 * mask radius)", "The maximum global peak search distance along Y from the particle box center", "0.0", 0.0);
 	mask_center_2d_x = my_input->GetFloatFromUser("2D mask X coordinate (A)", "X coordinate of 2D mask center", "100.0", 0.0);

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -853,24 +853,24 @@ void SimulateApp::DoInteractiveUserInput()
 
 	 if (this->do3d)
 	 {
-//		 // Check to make sure the sampling is sufficient, if not, oversample and bin at the end.
-//		 if (this->wanted_pixel_size > 0.8 && this->wanted_pixel_size <= 1.5)
-//		 {
-//			 wxPrintf("\nOversampling your 3d by a factor of 2 for calculation.\n");
-//			 this->wanted_pixel_size /= 2.0f;
-//			 this->bin3d = 2;
-//		 }
-//		 else if (this->wanted_pixel_size > 1.5 && this->wanted_pixel_size < 3.0)
-//		 {
-//			 wxPrintf("\nOversampling your 3d by a factor of 4 for calculation.\n");
-//
-//			 this->wanted_pixel_size /= 4.0f;
-//			 this->bin3d = 4;
-//		 }
-//		 else
-//		 {
-//			 //do nothing
-//		 }
+		 // Check to make sure the sampling is sufficient, if not, oversample and bin at the end.
+		 if (this->wanted_pixel_size > 0.5 && this->wanted_pixel_size <= 1.5)
+		 {
+			 wxPrintf("\nOversampling your 3d by a factor of 2 for calculation.\n");
+			 this->wanted_pixel_size /= 2.0f;
+			 this->bin3d = 2;
+		 }
+		 else if (this->wanted_pixel_size > 1.5 && this->wanted_pixel_size < 3.0)
+		 {
+			 wxPrintf("\nOversampling your 3d by a factor of 4 for calculation.\n");
+
+			 this->wanted_pixel_size /= 4.0f;
+			 this->bin3d = 4;
+		 }
+		 else
+		 {
+			 //do nothing
+		 }
 		 this->dose_per_frame			= my_input->GetFloatFromUser("electrons/Ang^2 in a frame at the specimen","","1.0",0.05,20.0);
 		 this->number_of_frames			= my_input->GetFloatFromUser("number of frames per movie (micrograph or tilt)","","30",1.0,1000.0);
 


### PR DESCRIPTION
This PR is mainly to incorporate changes niko made over the last ~15 months or so. These are mainly isolated to programs that are part of the template matching workflow. We worked closely together to inspect the others.

There are two commits, the other contains an important fix that let to the psi output image being incorrect in cases where the input image is temporarily rotated in memory for just the TM search. (For speed) There are several small corrections to GPU/TM code noted in that commit as well.

I did add configure help string formatting (#299), rework the option to disable compiler warnings to work with Alexis' change from WALL to W2 for intel, but also keep warnings on otherwise (unless --disable-warnings) #298. Removed the duplicate MKL section in configure.ac (#297) and finally regarding issue #296 re-wrote the --enable-latest-instruction-set so that it was more clear. @timothygrant80 no one ever commented on that issue. Please look at it if you aren't sure what I did here. I ended up assuming the original help string was _incorrect_ and that the default option should be no (otherwise it really should be --disable..._)