### PR TITLE
Thread bug curve

### DIFF
--- a/src/core/curve.cpp
+++ b/src/core/curve.cpp
@@ -864,11 +864,6 @@ int Curve::ReturnIndexOfNearestPreviousBin(float wanted_x)
 		return number_of_points - 1;
 	}
 
-	// wxPrintf("wanted_x: %f\n", wanted_x);
-	// wxPrintf("number of points: %d\n", number_of_points);
-	// wxPrintf("index: %d\n", index_of_last_point_used);
-	// PrintToStandardOut();
-
 	// Should never get here
 	MyDebugAssertTrue(false,"Oops, programming error\n");
 	return 0;

--- a/src/core/curve.cpp
+++ b/src/core/curve.cpp
@@ -836,6 +836,7 @@ int Curve::ReturnIndexOfNearestPreviousBin(float wanted_x)
 	MyDebugAssertTrue(number_of_points > 0, "No points in curve");
 	MyDebugAssertTrue(wanted_x >= data_x[0]  - (data_x[number_of_points-1]-data_x[0])*0.01 && wanted_x <= data_x[number_of_points-1]  + (data_x[number_of_points-1]-data_x[0])*0.01, "Wanted X (%f) falls outside of range (%f to %f)\n",wanted_x, data_x[0],data_x[number_of_points-1]);
 
+	
 	for (int counter = index_of_last_point_used; counter < number_of_points - 1; counter++)
 	{
 		if (wanted_x >=data_x[counter] && wanted_x < data_x[counter+1])
@@ -863,6 +864,7 @@ int Curve::ReturnIndexOfNearestPreviousBin(float wanted_x)
 		index_of_last_point_used = number_of_points - 1;
 		return number_of_points - 1;
 	}
+	
 
 	// Should never get here
 	MyDebugAssertTrue(false,"Oops, programming error\n");

--- a/src/core/curve.cpp
+++ b/src/core/curve.cpp
@@ -836,7 +836,6 @@ int Curve::ReturnIndexOfNearestPreviousBin(float wanted_x)
 	MyDebugAssertTrue(number_of_points > 0, "No points in curve");
 	MyDebugAssertTrue(wanted_x >= data_x[0]  - (data_x[number_of_points-1]-data_x[0])*0.01 && wanted_x <= data_x[number_of_points-1]  + (data_x[number_of_points-1]-data_x[0])*0.01, "Wanted X (%f) falls outside of range (%f to %f)\n",wanted_x, data_x[0],data_x[number_of_points-1]);
 
-
 	for (int counter = index_of_last_point_used; counter < number_of_points - 1; counter++)
 	{
 		if (wanted_x >=data_x[counter] && wanted_x < data_x[counter+1])
@@ -865,6 +864,10 @@ int Curve::ReturnIndexOfNearestPreviousBin(float wanted_x)
 		return number_of_points - 1;
 	}
 
+	// wxPrintf("wanted_x: %f\n", wanted_x);
+	// wxPrintf("number of points: %d\n", number_of_points);
+	// wxPrintf("index: %d\n", index_of_last_point_used);
+	// PrintToStandardOut();
 
 	// Should never get here
 	MyDebugAssertTrue(false,"Oops, programming error\n");

--- a/src/gui/AutoRefine3dPanel.cpp
+++ b/src/gui/AutoRefine3dPanel.cpp
@@ -1147,9 +1147,13 @@ void AutoRefinementManager::SetupMerge3dJob()
 
 	for (class_counter = 0; class_counter < active_refinement_package->number_of_classes; class_counter++)
 	{
-		wxString output_reconstruction_1			= "/dev/null";
-		wxString output_reconstruction_2			= "/dev/null";
-		wxString output_reconstruction_filtered		= main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
+		// wxString output_reconstruction_1			= "/dev/null";
+		// wxString output_reconstruction_2			= "/dev/null";
+		// wxString output_reconstruction_filtered		= main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
+
+		wxString output_reconstruction_1      = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map1.mrc", output_refinement->refinement_id, class_counter + 1);
+        wxString output_reconstruction_2        = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map2.mrc", output_refinement->refinement_id, class_counter + 1);
+        wxString output_reconstruction_filtered     = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
 
 		current_reference_filenames.Item(class_counter) = output_reconstruction_filtered;
 
@@ -2049,7 +2053,12 @@ void AutoRefinementManager::ProcessAllJobsFinished()
 			main_frame->current_project.database.AddReconstructionJob(current_reconstruction_id, active_refinement_package->asset_id, output_refinement->refinement_id, "", active_inner_mask_radius, active_mask_radius, current_resolution_limit_rec, current_score_weight_conversion, false, active_auto_crop, false, active_should_apply_blurring, active_smoothing_factor, class_counter + 1, long(temp_asset.asset_id));
 
 			temp_asset.asset_name = wxString::Format("Auto #%li (Rnd. %i) - Class #%i", current_output_refinement_id, number_of_rounds_run + 1, class_counter + 1);
-			temp_asset.filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
+			
+			temp_asset.half_map_1_filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map1.mrc", output_refinement->refinement_id, class_counter + 1);
+            temp_asset.half_map_2_filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map2.mrc", output_refinement->refinement_id, class_counter + 1);
+            temp_asset.filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
+			
+			//temp_asset.filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
 
 			output_refinement->reference_volume_ids.Add(current_reference_asset_ids[class_counter]);
 			current_reference_asset_ids[class_counter] = temp_asset.asset_id;

--- a/src/gui/AutoRefine3dPanel.cpp
+++ b/src/gui/AutoRefine3dPanel.cpp
@@ -1147,13 +1147,9 @@ void AutoRefinementManager::SetupMerge3dJob()
 
 	for (class_counter = 0; class_counter < active_refinement_package->number_of_classes; class_counter++)
 	{
-		// wxString output_reconstruction_1			= "/dev/null";
-		// wxString output_reconstruction_2			= "/dev/null";
-		// wxString output_reconstruction_filtered		= main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
-
-		wxString output_reconstruction_1      = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map1.mrc", output_refinement->refinement_id, class_counter + 1);
-        wxString output_reconstruction_2        = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map2.mrc", output_refinement->refinement_id, class_counter + 1);
-        wxString output_reconstruction_filtered     = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
+		wxString output_reconstruction_1			= "/dev/null";
+		wxString output_reconstruction_2			= "/dev/null";
+		wxString output_reconstruction_filtered		= main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
 
 		current_reference_filenames.Item(class_counter) = output_reconstruction_filtered;
 
@@ -2053,12 +2049,7 @@ void AutoRefinementManager::ProcessAllJobsFinished()
 			main_frame->current_project.database.AddReconstructionJob(current_reconstruction_id, active_refinement_package->asset_id, output_refinement->refinement_id, "", active_inner_mask_radius, active_mask_radius, current_resolution_limit_rec, current_score_weight_conversion, false, active_auto_crop, false, active_should_apply_blurring, active_smoothing_factor, class_counter + 1, long(temp_asset.asset_id));
 
 			temp_asset.asset_name = wxString::Format("Auto #%li (Rnd. %i) - Class #%i", current_output_refinement_id, number_of_rounds_run + 1, class_counter + 1);
-			
-			temp_asset.half_map_1_filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map1.mrc", output_refinement->refinement_id, class_counter + 1);
-            temp_asset.half_map_2_filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_map2.mrc", output_refinement->refinement_id, class_counter + 1);
-            temp_asset.filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
-			
-			//temp_asset.filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
+			temp_asset.filename = main_frame->current_project.volume_asset_directory.GetFullPath() + wxString::Format("/volume_%li_%i.mrc", output_refinement->refinement_id, class_counter + 1);
 
 			output_refinement->reference_volume_ids.Add(current_reference_asset_ids[class_counter]);
 			current_reference_asset_ids[class_counter] = temp_asset.asset_id;

--- a/src/programs/reconstruct3d/reconstruct3d.cpp
+++ b/src/programs/reconstruct3d/reconstruct3d.cpp
@@ -707,6 +707,9 @@ bool Reconstruct3DApp::DoCalculation()
 		current_ctf_image, current_beamtilt_image, unmasked_image, ssq_X, psi, rotation_angle, rotation_cache)
 	{ // for omp
 
+	Curve noise_power_spectrum_local; 
+	noise_power_spectrum_local = noise_power_spectrum;
+
 	input_image_local.Allocate(input_stack.ReturnXSize(), input_stack.ReturnYSize(), true);
 	projection_image.Allocate(original_box_size, original_box_size, false);
 	temp3_image_local.Allocate(original_box_size, original_box_size, false);
@@ -859,7 +862,7 @@ bool Reconstruct3DApp::DoCalculation()
 			if (normalize_particles)
 			{
 				temp_image_local.ForwardFFT();
-				temp_image_local.ApplyCurveFilter(&noise_power_spectrum);
+				temp_image_local.ApplyCurveFilter(&noise_power_spectrum_local);
 				if (use_input_reconstruction)
 				{
 					temp_image_local.PhaseShift(- input_parameters.x_shift / original_pixel_size, - input_parameters.y_shift / original_pixel_size);
@@ -1017,7 +1020,7 @@ bool Reconstruct3DApp::DoCalculation()
 				if (normalize_particles)
 				{
 					temp_image_local.ForwardFFT();
-					temp_image_local.ApplyCurveFilter(&noise_power_spectrum);
+					temp_image_local.ApplyCurveFilter(&noise_power_spectrum_local);
 					if (use_input_reconstruction)
 					{
 						temp_image_local.PhaseShift(- input_parameters.x_shift / original_pixel_size, - input_parameters.y_shift / original_pixel_size);
@@ -1104,7 +1107,8 @@ bool Reconstruct3DApp::DoCalculation()
 				if (normalize_particles)
 				{
 					input_particle.ForwardFFT();
-					input_particle.particle_image->ApplyCurveFilter(&noise_power_spectrum);
+					input_particle.particle_image->ApplyCurveFilter(&noise_power_spectrum_local);
+
 					if (use_input_reconstruction)
 					{
 						input_particle.particle_image->PhaseShift(- input_parameters.x_shift / original_pixel_size, - input_parameters.y_shift / original_pixel_size);


### PR DESCRIPTION
Fixed a threading bug in curve.cpp that resulted in crash behavior in the debug version of cisTEM. This bug was a result of multiple threads interacting with the same curve object in reconstruct3d, modifying values and changing the proper execution flow for other threads. Fix was to use local copies of said object for computation.  