### PR TITLE
Fix for number of jobs in merge2d setup

### DIFF
--- a/src/gui/MyRefine2DPanel.cpp
+++ b/src/gui/MyRefine2DPanel.cpp
@@ -1177,7 +1177,7 @@ void ClassificationManager::RunRefinementJobPostStarFileWrite(wxString input_sta
  */
 void ClassificationManager::RemoveFilesFromScratch()
 {
-	int number_of_refinement_jobs = active_run_profile.ReturnTotalJobs() - 1;
+	int number_of_refinement_jobs = active_run_profile.ReturnTotalJobs();
 	wxString dump_file;
 	for (int job_counter = 0; job_counter < number_of_refinement_jobs; job_counter++)
 	{
@@ -1219,7 +1219,7 @@ void ClassificationManager::RunMerge2dJob()
 {
 
 	long number_of_particles = output_classification->number_of_particles;
-	int number_of_refinement_jobs = std::min(my_parent->current_job_package.my_profile.ReturnTotalJobs() - 1,number_of_particles-1);
+	int number_of_refinement_jobs = std::min(my_parent->current_job_package.my_profile.ReturnTotalJobs(),number_of_particles);
 
 	running_job_type = MERGE;
 


### PR DESCRIPTION
Merge2d setup was still setup as though there was an independant master,
so number of jobs was set to number of jobs - 1.  This causes a crash
running with 1 process and n threads.  It probably also means that the
last dump file in 2D classifications was not being included prior to
this change.