### PR TITLE
Rewrite stopwatch class

### DIFF
--- a/.vscode_shared/BenHimes/c_cpp_properties.json
+++ b/.vscode_shared/BenHimes/c_cpp_properties.json
@@ -22,7 +22,7 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/**",
+                "${workspaceFolder}/src/**",
                 "/usr/local/include",
                 "/usr/include"
                 // "/groups/cryoadmin/software/WX/wx_static_3.05_INTEL/include/",

--- a/.vscode_shared/BenHimes/c_cpp_properties.json
+++ b/.vscode_shared/BenHimes/c_cpp_properties.json
@@ -24,10 +24,13 @@
             "includePath": [
                 "${workspaceFolder}/**",
                 "/usr/local/include",
-                "/usr/include",
-                "/admin/software/wxWidgets3_static_GNU/include/",
-                "/admin/software/wxWidgets3_static_GNU/include/wx-3.0",
-                "/admin/software/wxWidgets3_static_GNU/include/wx-3.0/wx"
+                "/usr/include"
+                // "/groups/cryoadmin/software/WX/wx_static_3.05_INTEL/include/",
+                // "/groups/cryoadmin/software/WX/wx_static_3.05_INTEL/include/wx-3.0",
+                // "/groups/cryoadmin/software/WX/wx_static_3.05_INTEL/include/wx-3.0/wx"
+                // "/groups/cryoadmin/software/WX/wx_static_3.05_GNU/include/",
+                // "/groups/cryoadmin/software/WX/wx_static_3.05_GNU/include/wx-3.0"
+                // "/groups/cryoadmin/software/WX/wx_static_3.05_GNU/include/wx-3.0/wx"
             ],
             "defines": [
                 "_FILE_OFFSET_BITS=64",
@@ -37,7 +40,7 @@
             ],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
-            "cppStandard": "gnu++11",
+            "cppStandard": "gnu++17",
             "configurationProvider": "ms-vscode.cmake-tools"
         }
     ],

--- a/.vscode_shared/BenHimes/settings.json
+++ b/.vscode_shared/BenHimes/settings.json
@@ -10,12 +10,12 @@
         "BUILD_GPU_FEATURES":true,
         "BUILD_STATIC_BINARIES":true,
         "BUILD_OpenMP":true,
-        "cisTEM_CUDA_TOOLKIT_PATH":"/admin/software/cuda-11.1/"
+        "cisTEM_CUDA_TOOLKIT_PATH":"/groups/cryoadmin/software/CUDA-TOOLKIT/cuda_11.3.1/"
         
     },
     "cmake.configureEnvironment": {
         "WX_CONFIG":"/admin/software/wxWidgets3_static_GNU/bin/wx-config",
-        "CUDACXX":"/admin/software/cuda-11.1/bin/nvcc",
+        "CUDACXX":"/groups/cryoadmin/software/CUDA-TOOLKIT/cuda_11.3.1/bin/nvcc",
         "CUDAARCHS":"70;75",
         "CUDAFLAGS":" --default-stream per-thread -m64  --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
      

--- a/.vscode_shared/BenHimes/tasks.json
+++ b/.vscode_shared/BenHimes/tasks.json
@@ -7,7 +7,7 @@
             "cuda_dir": "/groups/cryoadmin/software/CUDA-TOOLKIT/cuda_11.3.1",
             "wx_dir":"/groups/cryoadmin/software/WX/wx_static_3.05_",
             "build_dir": "${workspaceFolder}/build",
-            "compile_cores": "48"
+            "compile_cores": "24"
         }
     },
     "tasks": [
@@ -29,6 +29,17 @@
             "command": "cd ${build_dir}/Intel-gpu-debug && make -j${compile_cores}"
         },
 
+        {
+            "label": "CONFIG intel,gpu,debug,rotate",
+            "type": "shell",
+            "command": "mkdir -p ${build_dir}/Intel-gpu-debug-rotate && cd ${build_dir}/Intel-gpu-debug-rotate && CC=icc CXX=icpc ../../configure --enable-rotated-tm --enable-debugmode --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}INTEL/bin/wx-config"
+        },
+
+        {
+            "label": "BUILD intel,gpu,debug,rotate",
+            "type": "shell",
+            "command": "cd ${build_dir}/Intel-gpu-debug-rotate && make -j${compile_cores}"
+        },
         {
             "label": "CONFIG intel,gpu",
             "type": "shell",

--- a/.vscode_shared/BenHimes/tasks.json
+++ b/.vscode_shared/BenHimes/tasks.json
@@ -7,7 +7,7 @@
             "cuda_dir": "/groups/cryoadmin/software/CUDA-TOOLKIT/cuda_11.3.1",
             "wx_dir":"/groups/cryoadmin/software/WX/wx_static_3.05_",
             "build_dir": "${workspaceFolder}/build",
-            "compile_cores": "24"
+            "compile_cores": "48"
         }
     },
     "tasks": [
@@ -27,6 +27,17 @@
             "label": "BUILD intel,gpu,debug",
             "type": "shell",
             "command": "cd ${build_dir}/Intel-gpu-debug && make -j${compile_cores}"
+        },
+        
+        {
+            "label": "CONFIG intel,gpu,debug,noexp",
+            "type": "shell",
+            "command": "mkdir -p ${build_dir}/Intel-gpu-debug-noexp && cd ${build_dir}/Intel-gpu-debug-noexp && CC=icc CXX=icpc ../../configure  --enable-debugmode  --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}INTEL/bin/wx-config"
+        },
+        {
+            "label": "BUILD intel,gpu,debug,noexp",
+            "type": "shell",
+            "command": "cd ${build_dir}/Intel-gpu-debug-noexp && make -j${compile_cores}"
         },
 
         {

--- a/.vscode_shared/BenHimes/tasks.json
+++ b/.vscode_shared/BenHimes/tasks.json
@@ -4,10 +4,10 @@
     "version": "2.0.0",
     "options": {
         "env": {
-            "cuda_dir": "/admin/software/cuda-11.1",
-            "wx_dir":"/admin/software/wxWidgets3_static_INTEL/bin/wx-config",
+            "cuda_dir": "/groups/cryoadmin/software/CUDA-TOOLKIT/cuda_11.3.1",
+            "wx_dir":"/groups/cryoadmin/software/WX/wx_static_3.05_",
             "build_dir": "${workspaceFolder}/build",
-            "compile_cores": "56"
+            "compile_cores": "48"
         }
     },
     "tasks": [
@@ -21,7 +21,7 @@
         {
             "label": "CONFIG intel,gpu,debug",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/Intel-gpu-debug && cd ${build_dir}/Intel-gpu-debug && CC=icc CXX=icpc ../../configure  --enable-debugmode --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}"
+            "command": "mkdir -p ${build_dir}/Intel-gpu-debug && cd ${build_dir}/Intel-gpu-debug && CC=icc CXX=icpc ../../configure  --enable-debugmode --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}INTEL/bin/wx-config"
         },
         {
             "label": "BUILD intel,gpu,debug",
@@ -32,7 +32,7 @@
         {
             "label": "CONFIG intel,gpu",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/Intel-gpu && cd ${build_dir}/Intel-gpu && CC=icc CXX=icpc ../../configure  --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}"
+            "command": "mkdir -p ${build_dir}/Intel-gpu && cd ${build_dir}/Intel-gpu && CC=icc CXX=icpc ../../configure  --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}INTEL/bin/wx-config"
         },
         {
             "label": "BUILD intel,gpu",
@@ -42,13 +42,35 @@
         {
             "label": "CONFIG intel,gpu,samples,debug",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/Intel-gpu-samples-debug && cd ${build_dir}/Intel-gpu-samples-debug && CC=icc CXX=icpc ../../configure --enable-samples --enable-debugmode --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}"
+            "command": "mkdir -p ${build_dir}/Intel-gpu-samples-debug && cd ${build_dir}/Intel-gpu-samples-debug && CC=icc CXX=icpc ../../configure --enable-samples --enable-debugmode --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}INTEL/bin/wx-config"
         },
         {
             "label": "BUILD intel,gpu,samples,debug",
             "type": "shell",
             "command": "cd ${build_dir}/Intel-gpu-samples-debug && make -j${compile_cores}"
-        }
+        },
+
+        {
+            "label": "CONFIG intel,gpu,device-lto",
+            "type": "shell",
+            "command": "mkdir -p ${build_dir}/Intel-gpu-lto && cd ${build_dir}/Intel-gpu-lto && CC=icc CXX=icpc ../../configure  --with-oldest-gpu-arch=80 --with-target-gpu-arch=80 --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}INTEL/bin/wx-config"
+        },
+        {
+            "label": "BUILD intel,gpu,device-lto",
+            "type": "shell",
+            "command": "cd ${build_dir}/Intel-gpu-lto && make -j${compile_cores}"
+        },
+
+        {
+            "label": "CONFIG GNU ,gpu",
+            "type": "shell",
+            "command": "mkdir -p ${build_dir}/GNU-gpu && cd ${build_dir}/GNU-gpu && CC=gcc CXX=g++ ../../configure  --disable-mkl --enable-experimental --with-cuda=${cuda_dir} --enable-staticmode --enable-openmp  --with-wx-config=${wx_dir}GNU/bin/wx-config"
+        },
+        {
+            "label": "BUILD GNU,gpu",
+            "type": "shell",
+            "command": "cd  ${build_dir}/GNU-gpu && make -j${compile_cores}"
+        },
    
 
     ]

--- a/.vscode_shared/BenHimes/workspace.code-workspace
+++ b/.vscode_shared/BenHimes/workspace.code-workspace
@@ -3,5 +3,10 @@
         {
             "path": "../"
         }
-    ]
+    ],
+    "settings": {
+        "files.associations": {
+            "typeinfo": "cpp"
+        }
+    }
 }

--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -251,11 +251,13 @@ fi
 
 if test "x$is_cuda_ge_11" -eq "x1" ; then
   AC_MSG_NOTICE([CUDA >= 11.0, enabling --extra-device-vectorization])
-  NVCCFLAGS+=" --extra-device-vectorization"
+  NVCCFLAGS+=" --extra-device-vectorization -std=c++17" 
+else
+  NVCCFLAGS+=" -std=c++11" 
 fi
   
 #--extra-device-vectorization
-NVCCFLAGS+=" --default-stream per-thread -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -std=c++17 -Xcompiler= -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
+NVCCFLAGS+=" --default-stream per-thread -m64 -O3 --use_fast_math  -Xptxas --warn-on-local-memory-usage,--warn-on-spills, --generate-line-info -Xcompiler= -DGPU -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1"
 
 AC_ARG_ENABLE(gpu-cache-hints, AS_HELP_STRING([--disable-gpu-cache-hints],[Do not use the intrinsics for cache hints]),[
   if test "$enableval" = no; then

--- a/ax_cuda.m4
+++ b/ax_cuda.m4
@@ -249,7 +249,7 @@ else
 		
 fi
 
-if test "x$is_cuda_ge_11" -eq "1" ; then
+if test "x$is_cuda_ge_11" -eq "x1" ; then
   AC_MSG_NOTICE([CUDA >= 11.0, enabling --extra-device-vectorization])
   NVCCFLAGS+=" --extra-device-vectorization"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_LANG(C++)
 
 # Set this for the gpu makefile hack
 TOPSRCDIR=$srcdir
-if test "$TOPSRCDIR" = "." ; then
+if test "x$TOPSRCDIR" = "x." ; then
 	TOPSRCDIR=`pwd`
 fi
 # don't let the AC_PROG_CXX set default flags, set them back to input..
@@ -385,32 +385,30 @@ if test "x$SVN_CHECK" == "xyes" ; then
   fi
 fi
 
-if test x$compile_experimental = xtrue ; then
-
+if test $compile_experimental = true ; then
 AC_CHECK_PROG(GIT_CHECK,git,yes)
-AC_CHECK_FILE(/groups/himesb/git/cisTEM_downstream_bah/.git/HEAD,
+# If we have git, it must not be too old, e.g. 1.8 is still the default on older OS's like CentOS 7 
+is_git_new_enough=`git version | awk '{if($3 >= 2) print yes; else print no}'`
+if test "xis_git_new_enough" == "xno" ; then
+  	AC_MSG_NOTICE([your version of git is too old, you can updated on Centos 7 with sudo yum -y install https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm
+  	])
+else
+	
+AC_CHECK_FILE("$TOPSRCDIR/.git/HEAD",
   [
     if test "x$GIT_CHECK" == "xyes"; then 
-      # Get the current branch, which could have multiple refs, which is why we need the awk (*) marks the active branch.
-      AC_SUBST([CISTEM_CURRENT_BRANCH],[`git  branch --points-at  HEAD | awk '/^\*/{print $2}'`])
-      # Get the first reachable tag - number of commits since that tag - short commit hash
-      AC_SUBST([CISTEM_VERSION_tag_nCommits_commitish],[`git describe --tags`])
-      # Get both an easily parsed date, as well as a more readable date
-      AC_SUBST([CISTEM_TIME_YYMMDDHHMMSS],[`git show --no-patch --no-notes --pretty='%cd' --date=format:%y%m%d%H%M%S`])
-      AC_SUBST([CISTEM_TIME_READABLE],[`git show --no-patch --no-notes --pretty='%ci' --date=format:%y%m%d%H%M%S`]) 
-      # Get the git configured user name (I believe this is required to push up to the repo)
-      AC_SUBST([CISTEM_GIT_USERNAME],[`git config --get user.name`])
-
-      # Print out what we found
-      AC_MSG_NOTICE([CISTEM_CURRENT_BRANCH is $CISTEM_CURRENT_BRANCH])
-      AC_MSG_NOTICE([CISTEM_VERSION_tag_nCommits_commitish is $CISTEM_VERSION_tag_nCommits_commitish])
-      AC_MSG_NOTICE([CISTEM_TIME_YYMMDDHHMMSS is $CISTEM_TIME_YYMMDDHHMMSS])
-      AC_MSG_NOTICE([CISTEM_TIME_READABLE is $CISTEM_TIME_READABLE])
-      AC_MSG_NOTICE([CISTEM_GIT_USERNAME is $CISTEM_GIT_USERNAME])
-
+      # All the args require the extra double quotes to be properly formated later on.
       
-      CXXFLAGS="$CXXFLAGS -DCISTEM_CURRENT_BRANCH=\"\\\"${CISTEM_CURRENT_BRANCH}\\\"\" -DCISTEM_VERSION_tag_nCommits_commitish=\"\\\"${CISTEM_VERSION_tag_nCommits_commitish}\\\"\" -DCISTEM_TIME_YYMMDDHHMMSS=\"\\\"${CISTEM_TIME_YYMMDDHHMMSS}\\\"\" -DCISTEM_TIME_READABLE=\"\\\"${CISTEM_TIME_READABLE}\\\"\" -DCISTEM_GIT_USERNAME=\"\\\"${CISTEM_GIT_USERNAME}\\\"\""
-      CPPFLAGS="$CPPFLAGS -DCISTEM_CURRENT_BRANCH=\"\\\"${CISTEM_CURRENT_BRANCH}\\\"\" -DCISTEM_VERSION_tag_nCommits_commitish=\"\\\"${CISTEM_VERSION_tag_nCommits_commitish}\\\"\" -DCISTEM_TIME_YYMMDDHHMMSS=\"\\\"${CISTEM_TIME_YYMMDDHHMMSS}\\\"\" -DCISTEM_TIME_READABLE=\"\\\"${CISTEM_TIME_READABLE}\\\"\" -DCISTEM_GIT_USERNAME=\"\\\"${CISTEM_GIT_USERNAME}\\\"\""
+      # Get the current branch, which could have multiple refs, which is why we need the awk (*) marks the active branch.
+      AC_DEFINE_UNQUOTED([CISTEM_CURRENT_BRANCH],["`git  branch | awk '/^\*/{print $2}'`"])
+      # Get the first reachable tag - number of commits since that tag - short commit hash
+      AC_DEFINE_UNQUOTED([CISTEM_VERSION_TEXT],["`git describe --tags --dirty`"])
+      # Get both an easily parsed date, as well as a more readable date
+      AC_DEFINE_UNQUOTED([CISTEM_TIME_YYMMDDHHMMSS],["`git show --no-patch --no-notes --pretty='%cd' --date=format:%y%m%d%H%M%S`"])
+      AC_DEFINE_UNQUOTED([CISTEM_TIME_READABLE],["`git show --no-patch --no-notes --pretty='%ci' --date=format:%y%m%d%H%M%S`"]) 
+      # Get the git configured user name (I believe this is required to push up to the repo)
+      AC_DEFINE_UNQUOTED([CISTEM_GIT_USERNAME],["`git config --get user.name`"])
+      
     else
       AC_MSG_NOTICE([We DO NOT have git on path])
       AC_DEFINE(CISTEM_VERSION_TEXT, "2.0.0-alpha", [A hard coded version moved in from defines.h]) 
@@ -420,6 +418,8 @@ AC_CHECK_FILE(/groups/himesb/git/cisTEM_downstream_bah/.git/HEAD,
       AC_DEFINE(CISTEM_VERSION_TEXT, "2.0.0-alpha", [A hard coded version moved in from defines.h]) 
   ])
 fi
+
+fi # Check on git > vs2
 
 AC_SUBST(WX_LIBS)
 AC_SUBST(WX_CPPFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -221,7 +221,7 @@ AS_HELP_STRING([--with-fftw-dir=DIR],[Declare the root directory of fftw3, if it
 ])
 
 # experimental
-
+compile_experimental="false"
 AC_ARG_ENABLE(experimental, AS_HELP_STRING([--enable-experimental],[Compile with experimental [default=no]]),[
   if test "$enableval" = yes; then
   CPPFLAGS="$CPPFLAGS -DEXPERIMENTAL"
@@ -376,12 +376,50 @@ fi
 
 #fi
 
-# What SVN revision are we using?
-define([svnversion], esyscmd([sh -c "svnversion -n"]))dnl
-if test "x$want_cuda" != "xUnversioned directory"; then
- AC_DEFINE(CISTEM_SVN_REV, "svnversion", [SVN Revision])
+# What SVN revision are we using? Inner if clause will not work if svnversion is not callable
+AC_CHECK_PROG(SVB_CHECK,svnversion,yes)
+if test "x$SVN_CHECK" == "xyes" ; then
+  define([svnversion], esyscmd([sh -c "svnversion -n"]))dnl
+  if test "x$svnversion" != "xUnversioned directory"; then
+  AC_DEFINE(CISTEM_SVN_REV, "svnversion", [SVN Revision])
+  fi
 fi
 
+if test x$compile_experimental = xtrue ; then
+
+AC_CHECK_PROG(GIT_CHECK,git,yes)
+AC_CHECK_FILE(/groups/himesb/git/cisTEM_downstream_bah/.git/HEAD,
+  [
+    if test "x$GIT_CHECK" == "xyes"; then 
+      # Get the current branch, which could have multiple refs, which is why we need the awk (*) marks the active branch.
+      AC_SUBST([CISTEM_CURRENT_BRANCH],[`git  branch --points-at  HEAD | awk '/^\*/{print $2}'`])
+      # Get the first reachable tag - number of commits since that tag - short commit hash
+      AC_SUBST([CISTEM_VERSION_tag_nCommits_commitish],[`git describe --tags`])
+      # Get both an easily parsed date, as well as a more readable date
+      AC_SUBST([CISTEM_TIME_YYMMDDHHMMSS],[`git show --no-patch --no-notes --pretty='%cd' --date=format:%y%m%d%H%M%S`])
+      AC_SUBST([CISTEM_TIME_READABLE],[`git show --no-patch --no-notes --pretty='%ci' --date=format:%y%m%d%H%M%S`]) 
+      # Get the git configured user name (I believe this is required to push up to the repo)
+      AC_SUBST([CISTEM_GIT_USERNAME],[`git config --get user.name`])
+
+      # Print out what we found
+      AC_MSG_NOTICE([CISTEM_CURRENT_BRANCH is $CISTEM_CURRENT_BRANCH])
+      AC_MSG_NOTICE([CISTEM_VERSION_tag_nCommits_commitish is $CISTEM_VERSION_tag_nCommits_commitish])
+      AC_MSG_NOTICE([CISTEM_TIME_YYMMDDHHMMSS is $CISTEM_TIME_YYMMDDHHMMSS])
+      AC_MSG_NOTICE([CISTEM_TIME_READABLE is $CISTEM_TIME_READABLE])
+      AC_MSG_NOTICE([CISTEM_GIT_USERNAME is $CISTEM_GIT_USERNAME])
+
+      
+      CXXFLAGS="$CXXFLAGS -DCISTEM_CURRENT_BRANCH=\"\\\"${CISTEM_CURRENT_BRANCH}\\\"\" -DCISTEM_VERSION_tag_nCommits_commitish=\"\\\"${CISTEM_VERSION_tag_nCommits_commitish}\\\"\" -DCISTEM_TIME_YYMMDDHHMMSS=\"\\\"${CISTEM_TIME_YYMMDDHHMMSS}\\\"\" -DCISTEM_TIME_READABLE=\"\\\"${CISTEM_TIME_READABLE}\\\"\" -DCISTEM_GIT_USERNAME=\"\\\"${CISTEM_GIT_USERNAME}\\\"\""
+      CPPFLAGS="$CPPFLAGS -DCISTEM_CURRENT_BRANCH=\"\\\"${CISTEM_CURRENT_BRANCH}\\\"\" -DCISTEM_VERSION_tag_nCommits_commitish=\"\\\"${CISTEM_VERSION_tag_nCommits_commitish}\\\"\" -DCISTEM_TIME_YYMMDDHHMMSS=\"\\\"${CISTEM_TIME_YYMMDDHHMMSS}\\\"\" -DCISTEM_TIME_READABLE=\"\\\"${CISTEM_TIME_READABLE}\\\"\" -DCISTEM_GIT_USERNAME=\"\\\"${CISTEM_GIT_USERNAME}\\\"\""
+    else
+      AC_MSG_NOTICE([We DO NOT have git on path])
+      AC_DEFINE(CISTEM_VERSION_TEXT, "2.0.0-alpha", [A hard coded version moved in from defines.h]) 
+    fi
+  ], 
+  [
+      AC_DEFINE(CISTEM_VERSION_TEXT, "2.0.0-alpha", [A hard coded version moved in from defines.h]) 
+  ])
+fi
 
 AC_SUBST(WX_LIBS)
 AC_SUBST(WX_CPPFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -385,7 +385,6 @@ if test "x$SVN_CHECK" == "xyes" ; then
   fi
 fi
 
-if test $compile_experimental = true ; then
 AC_CHECK_PROG(GIT_CHECK,git,yes)
 # If we have git, it must not be too old, e.g. 1.8 is still the default on older OS's like CentOS 7 
 is_git_new_enough=`git version | awk '{if($3 >= 2) print yes; else print no}'`
@@ -406,8 +405,6 @@ AC_CHECK_FILE("$TOPSRCDIR/.git/HEAD",
       # Get both an easily parsed date, as well as a more readable date
       AC_DEFINE_UNQUOTED([CISTEM_TIME_YYMMDDHHMMSS],["`git show --no-patch --no-notes --pretty='%cd' --date=format:%y%m%d%H%M%S`"])
       AC_DEFINE_UNQUOTED([CISTEM_TIME_READABLE],["`git show --no-patch --no-notes --pretty='%ci' --date=format:%y%m%d%H%M%S`"]) 
-      # Get the git configured user name (I believe this is required to push up to the repo)
-      AC_DEFINE_UNQUOTED([CISTEM_GIT_USERNAME],["`git config --get user.name`"])
       
     else
       AC_MSG_NOTICE([We DO NOT have git on path])
@@ -419,7 +416,6 @@ AC_CHECK_FILE("$TOPSRCDIR/.git/HEAD",
   ])
 fi
 
-fi # Check on git > vs2
 
 AC_SUBST(WX_LIBS)
 AC_SUBST(WX_CPPFLAGS)

--- a/src/core/defines.h
+++ b/src/core/defines.h
@@ -1,5 +1,4 @@
 #define INTEGER_DATABASE_VERSION 2
-#define CISTEM_VERSION_TEXT "2.0.0-alpha"
 #define START_PORT 3000
 #define END_PORT 5000
 // Define PI constants

--- a/src/core/stopwatch.cpp
+++ b/src/core/stopwatch.cpp
@@ -1,18 +1,39 @@
 
 #include "core_headers.h"
 
+namespace cistem_timer_noop {
+
+// All the other methods are defined as inline in the header to ensure they are optimized out.
+StopWatch::StopWatch() {
+	// do nothing
+}	
+StopWatch::~StopWatch() {
+	// do nothing
+}
+
+}
+
+namespace cistem_timer {
 
 StopWatch::StopWatch()
 {
-	current_index = 0;
 	null_time = 0;
 	is_new = false;
 	is_set_overall = false;
+	is_recording_measured_time = false;
+	is_recording_elapsed_time = false;
+	is_entry_point = true;
+	number_of_events_being_recorded = 0;
 	
-	std::string dummyString = "Stopwatch Overhead";
-	event_names.push_back(dummyString);
+	current_index = (SpecialIDX)total_elapsed;
+	event_names.push_back("Total elapsed");
 	event_times.push_back(std::chrono::high_resolution_clock::now());
-	elapsed_times.push_back(stop(time_fmt, current_index));
+	elapsed_times.push_back(null_time);
+
+	current_index = (SpecialIDX)total_measured;
+	event_names.push_back("Total measured");
+	event_times.push_back(std::chrono::high_resolution_clock::now());
+	elapsed_times.push_back(null_time);
 }
 
 StopWatch::~StopWatch()
@@ -20,42 +41,127 @@ StopWatch::~StopWatch()
 	// Do nothing;
 }
 
-void StopWatch::start(std::string name)
+
+void StopWatch::record_start(std::string name) 
 {
-	
-	// We want to record the overall timing
-	if (! is_set_overall)
+	if (is_new)
 	{
-		// Set this first to prevent a recursive death
-		is_set_overall = true;
-		this->start("Overall");		
+		event_names.push_back(name);
+		current_index = event_names.size() - 1;
+		event_times.push_back(std::chrono::high_resolution_clock::now());
+		elapsed_times.push_back(null_time);
 	}
-	// Record overhead.
-	event_times[0] = std::chrono::high_resolution_clock::now();
-	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
-	check_for_name(name);
-	// Record the start time for the event.
-	if (! is_new)
+	else
 	{
 		event_times[current_index] = std::chrono::high_resolution_clock::now();
 	}
-
-	// Record the elapsed time for the start method.
-	elapsed_times[0] += stop(time_fmt, 0);
+	// We've added a new event if the idx is not special
+	if (current_index != (SpecialIDX)total_elapsed && current_index != (SpecialIDX)total_measured) {number_of_events_being_recorded++;}
 }
 
-void StopWatch::lap(std::string name)
+void StopWatch::record_end() 
 {
-	// Record overhead.
-	event_times[0] = std::chrono::high_resolution_clock::now();
-	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
-	check_for_name(name);
-	if (is_new) { wxPrintf("a new event name was encountered when calling Stopwatch::lap(%s) at line %d in file %s\n", name, __LINE__, __FILE__); exit(-1); }
+
 	elapsed_times[current_index] += stop(time_fmt, current_index);
-	elapsed_times[0] += stop(time_fmt, 0);
+	// We've removed an event if the idx is not special
+	if (current_index != (SpecialIDX)total_elapsed && current_index != (SpecialIDX)total_measured) {number_of_events_being_recorded--;}
 }
 
-void StopWatch::check_for_name(std::string name)
+void StopWatch::record_elapsed() 
+{
+	if (is_recording_elapsed_time)
+	{
+		elapsed_times[(SpecialIDX)total_elapsed] += stop(time_fmt,(SpecialIDX)total_elapsed);
+		is_recording_elapsed_time = false;
+	}
+  else
+	{
+		event_times[(SpecialIDX)total_elapsed] = std::chrono::high_resolution_clock::now();
+		is_recording_elapsed_time = true;
+	}
+}
+
+void StopWatch::record_measured()
+{
+	if (is_recording_measured_time)
+	{
+		if (number_of_events_being_recorded == 0)
+		{
+			// stop the measured time
+			elapsed_times[(SpecialIDX)total_measured] += stop(time_fmt, (SpecialIDX)total_measured);
+			is_recording_measured_time = false;
+		}
+	}
+	else
+	{
+		if (number_of_events_being_recorded > 0)
+		{
+			// start the measured time
+			event_times[(SpecialIDX)total_measured] = std::chrono::high_resolution_clock::now();
+			is_recording_measured_time = true;
+		}
+
+	}
+}
+
+void StopWatch::mark_entry_or_exit_point(bool threadsafe)
+{
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+	if (is_entry_point)
+	{
+		// If we are already recording, we don't need to do anything, but that shouldn't happen'
+		if ( ! is_recording_elapsed_time )
+		{
+			if (! is_set_overall) is_set_overall = true;
+			record_elapsed();
+		}
+
+		is_entry_point = false;
+
+	}
+	else
+	{
+		// If we are not recording on an exit point, we have a problem.
+		if (! is_recording_elapsed_time) { wxPrintf("a exit point was encounterd with no elapsed time being recorded Stopwatch at line %d in file %s\n", __LINE__, __FILE__); exit(-1); }
+		record_elapsed();
+		is_entry_point = true;
+	}
+
+}
+
+void StopWatch::start(std::string name, bool threadsafe)
+{
+	// Typically we only want to track a single thread, which is default. Override this with threadsafe = false;
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+	// We want to record the overall timing, triggered by the first start() call.
+	if (! is_set_overall)
+	{
+		// 
+		is_set_overall = true;
+		record_elapsed();
+	}
+
+	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
+	check_for_name_and_set_current_idx(name);
+	record_start(name);	
+	record_measured();
+
+}
+
+void StopWatch::lap(std::string name, bool threadsafe)
+{
+	// Typically we only want to track a single thread, which is default. Override this with threadsafe = false;
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+
+	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
+	check_for_name_and_set_current_idx(name);
+	if (is_new) { wxPrintf("a new event name was encountered when calling Stopwatch::lap(%s) at line %d in file %s\n", name, __LINE__, __FILE__); exit(-1); }
+	record_end();
+	record_measured();
+
+}
+
+void StopWatch::check_for_name_and_set_current_idx(std::string name)
 {
 	// Either add to an existing event, or create a new one.
 	for (size_t iName = 0; iName < event_names.size(); iName++)
@@ -73,22 +179,15 @@ void StopWatch::check_for_name(std::string name)
 
 	}
 
-	if (is_new)
-	{
-		event_names.push_back(name);
-		current_index = event_names.size() - 1;
-		event_times.push_back(std::chrono::high_resolution_clock::now());
-		elapsed_times.push_back(null_time);
-	}
 }
 
-void StopWatch::print_times()
+void StopWatch::print_times(bool threadsafe)
 {
+		// Typically we only want to track a single thread, which is default. Override this with threadsafe = false;
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+	if (is_recording_elapsed_time) record_elapsed();
 	
-	this->lap("Overall");
-	
-	uint64 total_time = 0;
-	uint64 missed_time = 0;
+
 	// It would be nice to have a variable option for printing the time format in a given rep different from what was recorded.
 	std::string time_string;
 	switch (time_fmt)
@@ -111,49 +210,31 @@ void StopWatch::print_times()
 
 	}
 	
-	// Subtract the overhead from the total time
-	elapsed_times[1] = elapsed_times[1] - elapsed_times[0];
-	
-	for (size_t iName = 0; iName < event_names.size(); iName++)
-	{
-		if (iName > 1)
-		{
-			total_time += elapsed_times[iName];
-		}
-		
-	}
-	
-	missed_time = elapsed_times[0] + elapsed_times[1] - total_time;
+
+
 		
 	wxPrintf("\n\n\t\t---------Timing Results---------\n\n");
 	for (size_t iName = 0; iName < event_names.size(); iName++)
 	{
+
 		convert_time(elapsed_times[iName]);
-		if ( iName == 0)
-		{
-			wxPrintf("\t\t%-20s : %ld %s\n", event_names[iName], elapsed_times[iName], time_string);
 
-		}
-		else 
+		switch( iName )
 		{
-			wxPrintf("\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)elapsed_times[iName]/(float)total_time);
 
+			case (SpecialIDX)total_elapsed: 
+				wxPrintf("\t\t%-32s : %2.2ld:%2.2ld:%2.2ld:%03ld\n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3]);
+				break;
+			case (SpecialIDX)total_measured:
+				wxPrintf("\t\t%-32s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)elapsed_times[iName]/(float)elapsed_times[(SpecialIDX)total_elapsed]);
+				break;
+			default:
+				wxPrintf("\t\t%-32s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)elapsed_times[iName]/(float)elapsed_times[(SpecialIDX)total_measured]);
+				break;
 		}
+
 	}
 	
-	convert_time(total_time);
-	if (missed_time > 0)
-	{
-		wxPrintf("\n\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n\n", "Total counted", hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)(total_time - missed_time)/(float)total_time);
-		convert_time(missed_time);
-		wxPrintf("\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld\n", "Total not-counted", hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3]);		
-	}
-	else
-	{
-		wxPrintf("\n\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld [ ??.??% ]\n\n", "Total counted", hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3]);
-		wxPrintf("\t\t%-20s : %s\n", "Total not-counted", "was negative indicating overlapping events.");		
-	}
-
 	wxPrintf("\n\t\t--------------------------------\n\n");
 
 }
@@ -162,7 +243,7 @@ void StopWatch::print_times()
 void StopWatch::convert_time(uint64_t microsec)
 {
 	// Time is stored in microseconds
-	uint64 time_rem;
+	uint64_t time_rem;
 	time_rem = microsec / 3600000000;
 	hrminsec[0] = time_rem;
 
@@ -230,3 +311,4 @@ uint64_t StopWatch::ticks(TimeFormat T, const time_pt& start_time, const time_pt
 
 }
 
+}

--- a/src/core/stopwatch.h
+++ b/src/core/stopwatch.h
@@ -5,54 +5,90 @@
  *      Author: himesb
  */
 
+
+namespace cistem_timer_noop {
+
 class StopWatch {
 
 
 public:
 
-	enum TimeFormat : int { NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS };
-	typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_pt;
+	StopWatch();
+	virtual ~StopWatch();
+
+	// dummy methods
+	inline void start(std::string name, bool thread_safe = true) {return;}
+	inline void lap(std::string name, bool thread_safe = true) {return;}
+	inline void print_times(bool thread_safe = true) {return;}
+	inline void mark_entry_or_exit_point(bool thread_safe = true) {return;}
+
+};
+
+} // namespace cistem_timer_noop
+
+namespace cistem_timer {
+class StopWatch {
 
 
-	std::vector<std::string> event_names = {};
-	std::vector<time_pt> 	 event_times = {};
-	std::vector<uint64_t> 	 elapsed_times = {};
-
-	uint64 hrminsec[4] = {0,0,0,0};
-	size_t current_index;
-	uint64_t null_time;
-	bool is_new;
-	bool is_set_overall;
-	TimeFormat time_fmt = MICROSECONDS;
-
+public:
 
 	StopWatch();
 	virtual ~StopWatch();
 
 
+
 	// Create or reuse event named "name", start timing. May overlap with other timing events.
-	void start(std::string name);
+	void start(std::string name, bool thread_safe = true);
 
 	// Record the elapsed time since last "start" for this event. Add to cummulative time.
-	void lap(std::string name);
-
-	// Check to see if an event named "name" already exists, if not, initialize it.
-	void check_for_name(std::string name);
+	void lap(std::string name, bool thread_safe = true);
 
 	// Print out all event times, including stopwatch overhead time.
-	void print_times();
+	void print_times(bool  thread_safe = true);
 
-	// Parse time into a more readable hours:minutes:seconds:milliseconds format for display.
-	void convert_time(uint64_t microsec);
+	// Start or pause the total elapsed time when passing a stopwatch pointer to a method. Place inside the method at the entry and exit point of the method call.
+	void mark_entry_or_exit_point(bool thread_safe = true);
+
+
+
 
 
 
 private:
 
+	enum TimeFormat : int { NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS };
+	enum SpecialIDX : int { total_elapsed = 0, total_measured = 1};
+	
+	typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_pt;
+
+	int number_of_events_being_recorded;
+	std::vector<std::string> event_names = {};
+	std::vector<time_pt> 	 event_times = {};
+	std::vector<uint64_t> 	 elapsed_times = {};
+
+	uint64_t hrminsec[4] = {0,0,0,0};
+	size_t current_index;
+	uint64_t null_time;
+	bool is_new;
+	bool is_set_overall;
+	bool is_recording_measured_time;
+	bool is_recording_elapsed_time;
+	bool is_entry_point;
+	TimeFormat time_fmt = MICROSECONDS;
+
 	uint64_t stop(TimeFormat T, int idx);
-
-
 	uint64_t ticks(TimeFormat T, const time_pt& start_time, const time_pt& end_time);
 
+	// Parse time into a more readable hours:minutes:seconds:milliseconds format for display.
+	void convert_time(uint64_t microsec);
+
+		// Check to see if an event named "name" already exists, if not, initialize it.
+	void check_for_name_and_set_current_idx(std::string name);
+
+	void record_start(std::string name);
+	void record_end();
+	void record_elapsed();
+	void record_measured();
 
 };
+} // namespace cistem_timer

--- a/src/gpu/DeviceManager.cu
+++ b/src/gpu/DeviceManager.cu
@@ -18,7 +18,7 @@ DeviceManager::~DeviceManager()
 {
 	if (is_manager_initialized)
 	{
-		checkCudaErrors(cudaDeviceReset());
+		cudaErr(cudaDeviceReset());
 	}
 
 };
@@ -92,7 +92,7 @@ void DeviceManager::Init(int wanted_number_of_gpus)
 		  if (total_mem < min_memory_total)
 		  {
 			  // Don't use this device. This might not be the best way to do this.
-			  checkCudaErrors(cudaDeviceReset());
+			  cudaErr(cudaDeviceReset());
 			  continue;
 		  }
 		  else if (free_mem > max_mem && free_mem > min_memory_available) { max_mem = free_mem; }
@@ -110,7 +110,7 @@ void DeviceManager::Init(int wanted_number_of_gpus)
 			  selected_GPU = iGPU;
 		  }
 	  }
-	  checkCudaErrors(cudaDeviceReset());
+	  cudaErr(cudaDeviceReset());
   }
 
   MyAssertTrue(selected_GPU >= 0, "No suitable GPU found. Terminating...");
@@ -129,9 +129,9 @@ void DeviceManager::SetGpu(int cpu_thread_idx)
   
 //	// Select the current device
 //	this->gpuIDX = -1;
-//	checkCudaErrors(cudaSetDevice(cpu_thread_idx % this->nGPUs));   // "% num_gpus" allows more CPU threads than GPU devices
+//	cudaErr(cudaSetDevice(cpu_thread_idx % this->nGPUs));   // "% num_gpus" allows more CPU threads than GPU devices
 	cudaErr(cudaSetDevice(this->gpuIDX));
-//	checkCudaErrors(cudaGetDevice(&gpuIDX));
+//	cudaErr(cudaGetDevice(&gpuIDX));
 
 //	wxPrintf("For thread %d of nGpus %d assigned %d\n",cpu_thread_idx, nGPUs, gpuIDX);
   
@@ -139,10 +139,10 @@ void DeviceManager::SetGpu(int cpu_thread_idx)
 
 };
 
-void DeviceManager::ReSetGpu()
+void DeviceManager::ResetGpu()
 {
 
-	checkCudaErrors(cudaSetDevice(this->gpuIDX));   // "% num_gpus" allows more CPU threads than GPU devices
+	cudaErr(cudaDeviceReset());   // "% num_gpus" allows more CPU threads than GPU devices
 
 };
 

--- a/src/gpu/DeviceManager.h
+++ b/src/gpu/DeviceManager.h
@@ -19,7 +19,7 @@ public:
 
   void Init(int wanted_number_of_gpus);
   void SetGpu(int cpu_thread_idx);
-  void ReSetGpu();
+  void ResetGpu();
   void ListDevices();
 
 private:

--- a/src/gpu/GpuImage.h
+++ b/src/gpu/GpuImage.h
@@ -267,6 +267,8 @@ public:
 	//  void CublasInit();
 	void NppInit();
 	void BufferInit(BufferType bt);
+	void BufferDestroy();
+
 
 
 
@@ -286,7 +288,7 @@ public:
 	Npp8u* countinrange_buffer;	bool is_allocated_countinrange_buffer;
 	Npp8u* l2norm_buffer;			bool is_allocated_l2norm_buffer;
 	Npp8u* dotproduct_buffer;		bool is_allocated_dotproduct_buffer;
-								bool is_allocated_16f_buffer;
+	bool is_allocated_16f_buffer;
 	int* clip_into_mask;		bool is_allocated_clip_into_mask; bool is_set_realLoadAndClipInto;
 
 

--- a/src/gpu/Histogram.cu
+++ b/src/gpu/Histogram.cu
@@ -105,11 +105,11 @@ Histogram::Histogram(int histogram_n_bins, float histogram_min, float histogram_
 Histogram::~Histogram()
 {
 
-//	if (is_allocated_histogram)
-//	{
-//		cudaErr(cudaFree(histogram));
-//		cudaErr(cudaFree(cummulative_histogram));
-//	}
+	if (is_allocated_histogram)
+	{
+		cudaErr(cudaFree(histogram));
+		cudaErr(cudaFree(cummulative_histogram));
+	}
 
 }
 	//FIXME

--- a/src/gpu/Histogram.cu
+++ b/src/gpu/Histogram.cu
@@ -44,10 +44,12 @@ __global__ void histogram_smem_atomics(const  __half* in, int4 dims, float *out,
 //      pixel_idx = (int)(floor((in[row * dims.w + col]-bin_min) / bin_inc));
       pixel_idx = __half2int_rd((in[row * dims.w + col]-bin_min) / bin_inc);
 
-
-      pixel_idx = MAX(MIN(pixel_idx,n_bins-1),0);
-
-      atomicAdd(&smem[pixel_idx], 1);
+	  // use nvidia integer instrinic max/min
+      //pixel_idx = max(min(pixel_idx,n_bins-1),0);
+	  if (pixel_idx >= 0 && pixel_idx < n_bins)
+	  {
+   	    atomicAdd(&smem[pixel_idx], 1);	
+	  }
 
     }
   }

--- a/src/gpu/TemplateMatchingCore.cu
+++ b/src/gpu/TemplateMatchingCore.cu
@@ -223,7 +223,7 @@ void TemplateMatchingCore::RunInnerLoop(Image &projection_filter, float c_pixel,
 			d_current_projection.AddConstant(-average_on_edge);
 
 			// The average in the full padded image will be different;
-			average_of_reals *= (d_current_projection.number_of_real_space_pixels / (float)d_padded_reference.number_of_real_space_pixels);
+			average_of_reals *= ((float)d_current_projection.number_of_real_space_pixels / (float)d_padded_reference.number_of_real_space_pixels);
 
 			d_current_projection.MultiplyByConstant(rsqrtf(  d_current_projection.ReturnSumOfSquares() / (float)d_padded_reference.number_of_real_space_pixels - (average_of_reals * average_of_reals)));
 			d_current_projection.ClipInto(&d_padded_reference, 0, false, 0, 0, 0, 0);
@@ -366,6 +366,7 @@ void TemplateMatchingCore::RunInnerLoop(Image &projection_filter, float c_pixel,
 
 	cudaErr(cudaFree(my_peaks));
 	cudaErr(cudaFree(my_stats));
+	cudaErr(cudaFree(my_new_peaks));
 
 }
 

--- a/src/gpu/gpu_core_headers.h
+++ b/src/gpu/gpu_core_headers.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifndef HEAVY_ERROR_CHECKING
-#define HEAVE_ERROR_CHECKING false
+#define HEAVY_ERROR_CHECKING false
 #endif
 
 #include "../core/core_headers.h"

--- a/src/gui/MyOverviewPanel.cpp
+++ b/src/gui/MyOverviewPanel.cpp
@@ -124,7 +124,8 @@ void MyOverviewPanel::SetWelcomeInfo()
 
 	InfoText->BeginAlignment(wxTEXT_ALIGNMENT_CENTRE);
 	InfoText->BeginFontSize(12);
-#ifdef EXPERIMENTAL
+
+
 	// Currently this is only defined in autoconf builds
 	#ifdef CISTEM_VERSION_TEXT
 		InfoText->WriteText(wxString::Format("cisTEM version : %s", CISTEM_VERSION_TEXT));
@@ -145,15 +146,7 @@ void MyOverviewPanel::SetWelcomeInfo()
 		// InfoText->WriteText(wxString::Format("Compiled from branch : %s", CISTEM_TIME_YYMMDDHHMMSS));
 		// InfoText->Newline();
 	#endif
-#else
-	InfoText->WriteText(wxString::Format("Version : %s (Compiled : %s )", CISTEM_VERSION_TEXT, __DATE__));
-	InfoText->Newline();
-	// Currently this is only defined in CMake builds
-	#ifdef CISTEM_GIT_COMMIT
-		InfoText->WriteText(wxString::Format("Git commit : %s", CISTEM_GIT_COMMIT));
-		InfoText->Newline();
-	#endif
-#endif
+
 	
 #ifdef CISTEM_SVN_REV
 	InfoText->WriteText(wxString::Format("SVN revision : %s", CISTEM_SVN_REV));

--- a/src/gui/MyOverviewPanel.cpp
+++ b/src/gui/MyOverviewPanel.cpp
@@ -124,16 +124,47 @@ void MyOverviewPanel::SetWelcomeInfo()
 
 	InfoText->BeginAlignment(wxTEXT_ALIGNMENT_CENTRE);
 	InfoText->BeginFontSize(12);
+#ifdef EXPERIMENTAL
+	// Currently this is only defined in autoconf builds
+	#ifdef CISTEM_VERSION_tag_nCommits_commitish
+		InfoText->WriteText(wxString::Format("cisTEM version : %s", CISTEM_VERSION_tag_nCommits_commitish));
+		InfoText->Newline();
+	#endif
+	// Currently this is only defined in autoconf builds
+	#ifdef CISTEM_GIT_USERNAME
+		InfoText->WriteText(wxString::Format("Compiled by: %s", CISTEM_GIT_USERNAME));
+		InfoText->Newline();
+	#endif
+	// Currently this is only defined in autoconf builds
+	#ifdef CISTEM_TIME_READABLE
+		InfoText->WriteText(wxString::Format("Commit datetime: %s", CISTEM_TIME_READABLE));
+		InfoText->Newline();
+	#endif
+	// Currently this is only defined in autoconf builds
+	#ifdef CISTEM_CURRENT_BRANCH
+		InfoText->WriteText(wxString::Format("From branch : %s", CISTEM_CURRENT_BRANCH));
+		InfoText->Newline();
+	#endif
+	// Currently this is only defined in autoconf builds, only include human readable time here
+	#ifdef CISTEM_TIME_YYMMDDHHMMSS
+		// InfoText->WriteText(wxString::Format("Compiled from branch : %s", CISTEM_TIME_YYMMDDHHMMSS));
+		// InfoText->Newline();
+	#endif
+#else
 	InfoText->WriteText(wxString::Format("Version : %s (Compiled : %s )", CISTEM_VERSION_TEXT, __DATE__));
 	InfoText->Newline();
+	// Currently this is only defined in CMake builds
+	#ifdef CISTEM_GIT_COMMIT
+		InfoText->WriteText(wxString::Format("Git commit : %s", CISTEM_GIT_COMMIT));
+		InfoText->Newline();
+	#endif
+#endif
+	
 #ifdef CISTEM_SVN_REV
 	InfoText->WriteText(wxString::Format("SVN revision : %s", CISTEM_SVN_REV));
 	InfoText->Newline();
 #endif
-#ifdef CISTEM_GIT_COMMIT
-	InfoText->WriteText(wxString::Format("Git commit : %s", CISTEM_GIT_COMMIT));
-	InfoText->Newline();
-#endif
+
 	InfoText->Newline();
 	InfoText->Newline();
 	InfoText->EndFontSize();

--- a/src/gui/MyOverviewPanel.cpp
+++ b/src/gui/MyOverviewPanel.cpp
@@ -131,11 +131,6 @@ void MyOverviewPanel::SetWelcomeInfo()
 		InfoText->Newline();
 	#endif
 	// Currently this is only defined in autoconf builds
-	#ifdef CISTEM_GIT_USERNAME
-		InfoText->WriteText(wxString::Format("Compiled by: %s", CISTEM_GIT_USERNAME));
-		InfoText->Newline();
-	#endif
-	// Currently this is only defined in autoconf builds
 	#ifdef CISTEM_TIME_READABLE
 		InfoText->WriteText(wxString::Format("Commit datetime: %s", CISTEM_TIME_READABLE));
 		InfoText->Newline();

--- a/src/gui/MyOverviewPanel.cpp
+++ b/src/gui/MyOverviewPanel.cpp
@@ -126,8 +126,8 @@ void MyOverviewPanel::SetWelcomeInfo()
 	InfoText->BeginFontSize(12);
 #ifdef EXPERIMENTAL
 	// Currently this is only defined in autoconf builds
-	#ifdef CISTEM_VERSION_tag_nCommits_commitish
-		InfoText->WriteText(wxString::Format("cisTEM version : %s", CISTEM_VERSION_tag_nCommits_commitish));
+	#ifdef CISTEM_VERSION_TEXT
+		InfoText->WriteText(wxString::Format("cisTEM version : %s", CISTEM_VERSION_TEXT));
 		InfoText->Newline();
 	#endif
 	// Currently this is only defined in autoconf builds

--- a/src/gui/MyRefine2DPanel.cpp
+++ b/src/gui/MyRefine2DPanel.cpp
@@ -1177,7 +1177,7 @@ void ClassificationManager::RunRefinementJobPostStarFileWrite(wxString input_sta
  */
 void ClassificationManager::RemoveFilesFromScratch()
 {
-	int number_of_refinement_jobs = active_run_profile.ReturnTotalJobs() - 1;
+	int number_of_refinement_jobs = active_run_profile.ReturnTotalJobs();
 	wxString dump_file;
 	for (int job_counter = 0; job_counter < number_of_refinement_jobs; job_counter++)
 	{
@@ -1219,7 +1219,7 @@ void ClassificationManager::RunMerge2dJob()
 {
 
 	long number_of_particles = output_classification->number_of_particles;
-	int number_of_refinement_jobs = std::min(my_parent->current_job_package.my_profile.ReturnTotalJobs() - 1,number_of_particles-1);
+	int number_of_refinement_jobs = std::min(my_parent->current_job_package.my_profile.ReturnTotalJobs(),number_of_particles);
 
 	running_job_type = MERGE;
 

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -581,8 +581,7 @@ bool MatchTemplateApp::DoCalculation()
 	if (factorizable_x - original_input_image_x > max_padding) max_padding = factorizable_x - original_input_image_x;
 	if (factorizable_y - original_input_image_y > max_padding) max_padding = factorizable_y - original_input_image_y;
 
-
-	wxPrintf("old x, y; new x, y = %i %i %i %i\n", input_image.logical_x_dimension, input_image.logical_y_dimension, factorizable_x, factorizable_y);
+	wxPrintf("old x, y; new x, y = %i %i ", input_image.logical_x_dimension, input_image.logical_y_dimension);
 
 
 	input_image.Resize(factorizable_x, factorizable_y, 1, input_image.ReturnAverageOfRealValuesOnEdges());
@@ -596,7 +595,7 @@ bool MatchTemplateApp::DoCalculation()
 		input_image.Rotate2DInPlaceBy90Degrees(true);
 	}
 #endif
-
+	wxPrintf("%i %i\n", input_image.logical_x_dimension, input_image.logical_y_dimension);
 	}
 	padded_reference.Allocate(input_image.logical_x_dimension, input_image.logical_y_dimension, 1);
 	max_intensity_projection.Allocate(input_image.logical_x_dimension, input_image.logical_y_dimension, 1);
@@ -1184,6 +1183,7 @@ bool MatchTemplateApp::DoCalculation()
 	if (is_rotated_by_90)
 	{
 		// swap back all the images prior to re-sizing
+		input_image.BackwardFFT();
 		input_image.Rotate2DInPlaceBy90Degrees(false);
 		max_intensity_projection.Rotate2DInPlaceBy90Degrees(false);
 
@@ -1544,6 +1544,8 @@ bool MatchTemplateApp::DoCalculation()
 		{
 			delete [] GPU;
 		}
+		
+		//  gpuDev.ResetGpu();
 	#endif
 
 	if (is_running_locally == true)

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -1532,9 +1532,19 @@ bool MatchTemplateApp::DoCalculation()
 		}
 
 		SendProgramDefinedResultToMaster(result, number_of_result_floats, image_number_for_gui, number_of_jobs_per_image_in_gui);
+		// The result should not be deleted here, as the worker thread will free it up once it has been send to the master
+		// delete [] result;
 	}
 
 	delete [] histogram_data;
+	delete [] correlation_pixel_sum;
+	delete [] correlation_pixel_sum_of_squares;
+	#ifdef ENABLEGPU
+		if (use_gpu)
+		{
+			delete [] GPU;
+		}
+	#endif
 
 	if (is_running_locally == true)
 	{

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -3,6 +3,7 @@
 #include "scattering_potential.h"
 #include "wave_function_propagator.h"
 
+using namespace cistem_timer;
 
 //#define DO_BEAM_TILT_FULL true
 


### PR DESCRIPTION
# Only the last commit is unique to this PR, the others are all in the previous PR #316

# Fixes
- Moves all but necessary methods/vars to private to prevent mistaken manipulation of bools etc that would break the stopwatch
- Removes tracking of overhead, and instead now tracks total elapsed time and total measured time, which eliminates the occasional error with negative uints, and gives a better picture of code coverage.

# Adds
- Now "threadsafe": by default the public methods return if the current thread ID is not 0. (if no openmp, thread id is always 0 as well.)
- gating method that is placed at (internal) entry/exit points of a method call (e.g. unblur_refinement) so that the elapsed time is paused when that method is not running. This allows for a "sub-timer" to be passed to method calls to get finer granularity in timing.

# Known issues
- Stopwatch still does not handle overlap gracefully: the percent runtime becomes irrelevant

# New ideas
- Introduces an approach to get the behavior of a macro (e.g. MyDebugAssert) with a more complicated object. There is now a "cistem_timer" and "cistem_timer_noop" namespace defined. They can be used and mixed as follows:
1) in global declarative region, just put in "using cistem_timer". Then any calls to StopWatch::methods will be as normal
2) in global declarative region, place "using cistem_timer(_noop)" under control of a preprocessor define, such that the "noop" namespace can be invoked(or not) with a configure option.
🧨 The noop namespace defines all the methods as inline such that the compiler optimizes them out, and there is ***no function call inserted into the compiled assembly***
3) In combination with the previous (control via preprocesser define) you can also instantiate a StopWatch object by directly using the namespace

E.g.

```code
#include core_headers.h

#ifdef ENABLE_PROFILING
using namespace cistem_timer
#else
using namespace cistem_timer_noop
#endif
-----
program variables etc.
-----
cistem_timer::StopWatch always_on_timer; // invoke namespace directly, this timer always runs
Stopwatch profiler; // relies on the using directive, gated by the preprocessor define

```
