### PR TITLE
Rewrite of the stopwatch class to introduce namespace/noop

### DIFF
--- a/src/core/stopwatch.cpp
+++ b/src/core/stopwatch.cpp
@@ -1,18 +1,39 @@
 
 #include "core_headers.h"
 
+namespace cistem_timer_noop {
+
+// All the other methods are defined as inline in the header to ensure they are optimized out.
+StopWatch::StopWatch() {
+	// do nothing
+}	
+StopWatch::~StopWatch() {
+	// do nothing
+}
+
+}
+
+namespace cistem_timer {
 
 StopWatch::StopWatch()
 {
-	current_index = 0;
 	null_time = 0;
 	is_new = false;
 	is_set_overall = false;
+	is_recording_measured_time = false;
+	is_recording_elapsed_time = false;
+	is_entry_point = true;
+	number_of_events_being_recorded = 0;
 	
-	std::string dummyString = "Stopwatch Overhead";
-	event_names.push_back(dummyString);
+	current_index = (SpecialIDX)total_elapsed;
+	event_names.push_back("Total elapsed");
 	event_times.push_back(std::chrono::high_resolution_clock::now());
-	elapsed_times.push_back(stop(time_fmt, current_index));
+	elapsed_times.push_back(null_time);
+
+	current_index = (SpecialIDX)total_measured;
+	event_names.push_back("Total measured");
+	event_times.push_back(std::chrono::high_resolution_clock::now());
+	elapsed_times.push_back(null_time);
 }
 
 StopWatch::~StopWatch()
@@ -20,42 +41,127 @@ StopWatch::~StopWatch()
 	// Do nothing;
 }
 
-void StopWatch::start(std::string name)
+
+void StopWatch::record_start(std::string name) 
 {
-	
-	// We want to record the overall timing
-	if (! is_set_overall)
+	if (is_new)
 	{
-		// Set this first to prevent a recursive death
-		is_set_overall = true;
-		this->start("Overall");		
+		event_names.push_back(name);
+		current_index = event_names.size() - 1;
+		event_times.push_back(std::chrono::high_resolution_clock::now());
+		elapsed_times.push_back(null_time);
 	}
-	// Record overhead.
-	event_times[0] = std::chrono::high_resolution_clock::now();
-	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
-	check_for_name(name);
-	// Record the start time for the event.
-	if (! is_new)
+	else
 	{
 		event_times[current_index] = std::chrono::high_resolution_clock::now();
 	}
-
-	// Record the elapsed time for the start method.
-	elapsed_times[0] += stop(time_fmt, 0);
+	// We've added a new event if the idx is not special
+	if (current_index != (SpecialIDX)total_elapsed && current_index != (SpecialIDX)total_measured) {number_of_events_being_recorded++;}
 }
 
-void StopWatch::lap(std::string name)
+void StopWatch::record_end() 
 {
-	// Record overhead.
-	event_times[0] = std::chrono::high_resolution_clock::now();
-	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
-	check_for_name(name);
-	if (is_new) { wxPrintf("a new event name was encountered when calling Stopwatch::lap(%s) at line %d in file %s\n", name, __LINE__, __FILE__); exit(-1); }
+
 	elapsed_times[current_index] += stop(time_fmt, current_index);
-	elapsed_times[0] += stop(time_fmt, 0);
+	// We've removed an event if the idx is not special
+	if (current_index != (SpecialIDX)total_elapsed && current_index != (SpecialIDX)total_measured) {number_of_events_being_recorded--;}
 }
 
-void StopWatch::check_for_name(std::string name)
+void StopWatch::record_elapsed() 
+{
+	if (is_recording_elapsed_time)
+	{
+		elapsed_times[(SpecialIDX)total_elapsed] += stop(time_fmt,(SpecialIDX)total_elapsed);
+		is_recording_elapsed_time = false;
+	}
+  else
+	{
+		event_times[(SpecialIDX)total_elapsed] = std::chrono::high_resolution_clock::now();
+		is_recording_elapsed_time = true;
+	}
+}
+
+void StopWatch::record_measured()
+{
+	if (is_recording_measured_time)
+	{
+		if (number_of_events_being_recorded == 0)
+		{
+			// stop the measured time
+			elapsed_times[(SpecialIDX)total_measured] += stop(time_fmt, (SpecialIDX)total_measured);
+			is_recording_measured_time = false;
+		}
+	}
+	else
+	{
+		if (number_of_events_being_recorded > 0)
+		{
+			// start the measured time
+			event_times[(SpecialIDX)total_measured] = std::chrono::high_resolution_clock::now();
+			is_recording_measured_time = true;
+		}
+
+	}
+}
+
+void StopWatch::mark_entry_or_exit_point(bool threadsafe)
+{
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+	if (is_entry_point)
+	{
+		// If we are already recording, we don't need to do anything, but that shouldn't happen'
+		if ( ! is_recording_elapsed_time )
+		{
+			if (! is_set_overall) is_set_overall = true;
+			record_elapsed();
+		}
+
+		is_entry_point = false;
+
+	}
+	else
+	{
+		// If we are not recording on an exit point, we have a problem.
+		if (! is_recording_elapsed_time) { wxPrintf("a exit point was encounterd with no elapsed time being recorded Stopwatch at line %d in file %s\n", __LINE__, __FILE__); exit(-1); }
+		record_elapsed();
+		is_entry_point = true;
+	}
+
+}
+
+void StopWatch::start(std::string name, bool threadsafe)
+{
+	// Typically we only want to track a single thread, which is default. Override this with threadsafe = false;
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+	// We want to record the overall timing, triggered by the first start() call.
+	if (! is_set_overall)
+	{
+		// 
+		is_set_overall = true;
+		record_elapsed();
+	}
+
+	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
+	check_for_name_and_set_current_idx(name);
+	record_start(name);	
+	record_measured();
+
+}
+
+void StopWatch::lap(std::string name, bool threadsafe)
+{
+	// Typically we only want to track a single thread, which is default. Override this with threadsafe = false;
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+
+	// Check to see if the event has been encountered. If not, first create it and set elapsed time to zero. Return the events index.
+	check_for_name_and_set_current_idx(name);
+	if (is_new) { wxPrintf("a new event name was encountered when calling Stopwatch::lap(%s) at line %d in file %s\n", name, __LINE__, __FILE__); exit(-1); }
+	record_end();
+	record_measured();
+
+}
+
+void StopWatch::check_for_name_and_set_current_idx(std::string name)
 {
 	// Either add to an existing event, or create a new one.
 	for (size_t iName = 0; iName < event_names.size(); iName++)
@@ -73,22 +179,15 @@ void StopWatch::check_for_name(std::string name)
 
 	}
 
-	if (is_new)
-	{
-		event_names.push_back(name);
-		current_index = event_names.size() - 1;
-		event_times.push_back(std::chrono::high_resolution_clock::now());
-		elapsed_times.push_back(null_time);
-	}
 }
 
-void StopWatch::print_times()
+void StopWatch::print_times(bool threadsafe)
 {
+		// Typically we only want to track a single thread, which is default. Override this with threadsafe = false;
+	if (threadsafe && ReturnThreadNumberOfCurrentThread() != 0) return;
+	if (is_recording_elapsed_time) record_elapsed();
 	
-	this->lap("Overall");
-	
-	uint64 total_time = 0;
-	uint64 missed_time = 0;
+
 	// It would be nice to have a variable option for printing the time format in a given rep different from what was recorded.
 	std::string time_string;
 	switch (time_fmt)
@@ -111,49 +210,31 @@ void StopWatch::print_times()
 
 	}
 	
-	// Subtract the overhead from the total time
-	elapsed_times[1] = elapsed_times[1] - elapsed_times[0];
-	
-	for (size_t iName = 0; iName < event_names.size(); iName++)
-	{
-		if (iName > 1)
-		{
-			total_time += elapsed_times[iName];
-		}
-		
-	}
-	
-	missed_time = elapsed_times[0] + elapsed_times[1] - total_time;
+
+
 		
 	wxPrintf("\n\n\t\t---------Timing Results---------\n\n");
 	for (size_t iName = 0; iName < event_names.size(); iName++)
 	{
+
 		convert_time(elapsed_times[iName]);
-		if ( iName == 0)
-		{
-			wxPrintf("\t\t%-20s : %ld %s\n", event_names[iName], elapsed_times[iName], time_string);
 
-		}
-		else 
+		switch( iName )
 		{
-			wxPrintf("\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)elapsed_times[iName]/(float)total_time);
 
+			case (SpecialIDX)total_elapsed: 
+				wxPrintf("\t\t%-32s : %2.2ld:%2.2ld:%2.2ld:%03ld\n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3]);
+				break;
+			case (SpecialIDX)total_measured:
+				wxPrintf("\t\t%-32s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)elapsed_times[iName]/(float)elapsed_times[(SpecialIDX)total_elapsed]);
+				break;
+			default:
+				wxPrintf("\t\t%-32s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n", event_names[iName], hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)elapsed_times[iName]/(float)elapsed_times[(SpecialIDX)total_measured]);
+				break;
 		}
+
 	}
 	
-	convert_time(total_time);
-	if (missed_time > 0)
-	{
-		wxPrintf("\n\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld  %7.2f% \n\n", "Total counted", hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3],100.0f*(float)(total_time - missed_time)/(float)total_time);
-		convert_time(missed_time);
-		wxPrintf("\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld\n", "Total not-counted", hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3]);		
-	}
-	else
-	{
-		wxPrintf("\n\t\t%-20s : %2.2ld:%2.2ld:%2.2ld:%03ld [ ??.??% ]\n\n", "Total counted", hrminsec[0], hrminsec[1], hrminsec[2], hrminsec[3]);
-		wxPrintf("\t\t%-20s : %s\n", "Total not-counted", "was negative indicating overlapping events.");		
-	}
-
 	wxPrintf("\n\t\t--------------------------------\n\n");
 
 }
@@ -162,7 +243,7 @@ void StopWatch::print_times()
 void StopWatch::convert_time(uint64_t microsec)
 {
 	// Time is stored in microseconds
-	uint64 time_rem;
+	uint64_t time_rem;
 	time_rem = microsec / 3600000000;
 	hrminsec[0] = time_rem;
 

--- a/src/core/stopwatch.h
+++ b/src/core/stopwatch.h
@@ -5,54 +5,90 @@
  *      Author: himesb
  */
 
+
+namespace cistem_timer_noop {
+
 class StopWatch {
 
 
 public:
 
-	enum TimeFormat : int { NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS };
-	typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_pt;
+	StopWatch();
+	virtual ~StopWatch();
+
+	// dummy methods
+	inline void start(std::string name, bool thread_safe = true) {return;}
+	inline void lap(std::string name, bool thread_safe = true) {return;}
+	inline void print_times(bool thread_safe = true) {return;}
+	inline void mark_entry_or_exit_point(bool thread_safe = true) {return;}
+
+};
+
+} // namespace cistem_timer_noop
+
+namespace cistem_timer {
+class StopWatch {
 
 
-	std::vector<std::string> event_names = {};
-	std::vector<time_pt> 	 event_times = {};
-	std::vector<uint64_t> 	 elapsed_times = {};
-
-	uint64 hrminsec[4] = {0,0,0,0};
-	size_t current_index;
-	uint64_t null_time;
-	bool is_new;
-	bool is_set_overall;
-	TimeFormat time_fmt = MICROSECONDS;
-
+public:
 
 	StopWatch();
 	virtual ~StopWatch();
 
 
+
 	// Create or reuse event named "name", start timing. May overlap with other timing events.
-	void start(std::string name);
+	void start(std::string name, bool thread_safe = true);
 
 	// Record the elapsed time since last "start" for this event. Add to cummulative time.
-	void lap(std::string name);
-
-	// Check to see if an event named "name" already exists, if not, initialize it.
-	void check_for_name(std::string name);
+	void lap(std::string name, bool thread_safe = true);
 
 	// Print out all event times, including stopwatch overhead time.
-	void print_times();
+	void print_times(bool  thread_safe = true);
 
-	// Parse time into a more readable hours:minutes:seconds:milliseconds format for display.
-	void convert_time(uint64_t microsec);
+	// Start or pause the total elapsed time when passing a stopwatch pointer to a method. Place inside the method at the entry and exit point of the method call.
+	void mark_entry_or_exit_point(bool thread_safe = true);
+
+
+
 
 
 
 private:
 
+	enum TimeFormat : int { NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS };
+	enum SpecialIDX : int { total_elapsed = 0, total_measured = 1};
+	
+	typedef std::chrono::time_point<std::chrono::high_resolution_clock> time_pt;
+
+	int number_of_events_being_recorded;
+	std::vector<std::string> event_names = {};
+	std::vector<time_pt> 	 event_times = {};
+	std::vector<uint64_t> 	 elapsed_times = {};
+
+	uint64_t hrminsec[4] = {0,0,0,0};
+	size_t current_index;
+	uint64_t null_time;
+	bool is_new;
+	bool is_set_overall;
+	bool is_recording_measured_time;
+	bool is_recording_elapsed_time;
+	bool is_entry_point;
+	TimeFormat time_fmt = MICROSECONDS;
+
 	uint64_t stop(TimeFormat T, int idx);
-
-
 	uint64_t ticks(TimeFormat T, const time_pt& start_time, const time_pt& end_time);
 
+	// Parse time into a more readable hours:minutes:seconds:milliseconds format for display.
+	void convert_time(uint64_t microsec);
+
+		// Check to see if an event named "name" already exists, if not, initialize it.
+	void check_for_name_and_set_current_idx(std::string name);
+
+	void record_start(std::string name);
+	void record_end();
+	void record_elapsed();
+	void record_measured();
 
 };
+} // namespace cistem_timer

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -3,6 +3,7 @@
 #include "scattering_potential.h"
 #include "wave_function_propagator.h"
 
+using namespace cistem_timer;
 
 //#define DO_BEAM_TILT_FULL true
 


### PR DESCRIPTION
# Fixes
- Moves all but necessary methods/vars to private to prevent mistaken manipulation of bools etc that would break the stopwatch
- Removes tracking of overhead, and instead now tracks total elapsed time and total measured time, which eliminates the occasional error with negative uints, and gives a better picture of code coverage.

# Adds
- Now "threadsafe": by default the public methods return if the current thread ID is not 0. (if no openmp, thread id is always 0 as well.)
- gating method that is placed at (internal) entry/exit points of a method call (e.g. unblur_refinement) so that the elapsed time is paused when that method is not running. This allows for a "sub-timer" to be passed to method calls to get finer granularity in timing.

# Basic documentation
[draft docs](https://bhimes.github.io/cisTEM_docs/docs/dev/howto/Utilities/debugging_profiling.html)

# Known issues
- Stopwatch still does not handle overlap gracefully: the percent runtime becomes irrelevant

# New ideas
- Introduces an approach to get the behavior of a macro (e.g. MyDebugAssert) with a more complicated object. There is now a "cistem_timer" and "cistem_timer_noop" namespace defined. They can be used and mixed as follows:
1) in global declarative region, just put in "using cistem_timer". Then any calls to StopWatch::methods will be as normal
2) in global declarative region, place "using cistem_timer(_noop)" under control of a preprocessor define, such that the "noop" namespace can be invoked(or not) with a configure option.
🧨 The noop namespace defines all the methods as inline such that the compiler optimizes them out, and there is ***no function call inserted into the compiled assembly***
3) In combination with the previous (control via preprocesser define) you can also instantiate a StopWatch object by directly using the namespace

E.g.

```code
#include core_headers.h

#ifdef ENABLE_PROFILING
using namespace cistem_timer
#else
using namespace cistem_timer_noop
#endif
-----
program variables etc.
-----
cistem_timer::StopWatch always_on_timer; // invoke namespace directly, this timer always runs
Stopwatch profiler; // relies on the using directive, gated by the preprocessor define

```
