### PR TITLE
Fixes known_astigmatism bug and re-enables its use in determining amp…

### DIFF
--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -2494,10 +2494,11 @@ void SimulateApp::probability_density_2d(PDB *pdb_ensemble, int time_step)
 		if (SAVE_REF) { nLoops = 2; }
 		 WaveFunctionPropagator wave_function(this->set_real_part_wave_function_in, objective_aperture, wanted_pixel_size, number_of_threads, beam_tilt_x, beam_tilt_y, DO_BEAM_TILT_FULL, propagator_distance);
 
+    float avg_defocus = 0.5f * (wanted_defocus_1_in_angstroms + wanted_defocus_2_in_angstroms);
 		 // TODO redundancies with SetCTF and fit params, fit params etc.
 		 wave_function.SetFitParams(wanted_pixel_size, wanted_acceleration_voltage, wanted_spherical_aberration, 0.0f,
 				 	 	 	 	 	std::max(768,ReturnClosestFactorizedUpper(std::max(coords.GetLargestSpecimenVolume().x,coords.GetLargestSpecimenVolume().y),5,true)),
-									20.0f, wanted_pixel_size*2.5, wanted_defocus_1_in_angstroms - 1000.0f, wanted_defocus_1_in_angstroms + 1000.0f, number_of_threads, 1.0f);
+									20.0f, wanted_pixel_size*2.5, avg_defocus - 1000.0f, avg_defocus + 1000.0f, number_of_threads, 1.0f);
 
 //		WaveFunctionPropagator wave_function(this->set_real_part_wave_function_in, wanted_amplitude_contrast, wanted_pixel_size, number_of_threads, beam_tilt_x, beam_tilt_y, DO_BEAM_TILT_FULL);
 

--- a/src/programs/simulate/wave_function_propagator.cpp
+++ b/src/programs/simulate/wave_function_propagator.cpp
@@ -813,7 +813,7 @@ void WaveFunctionPropagator::ReturnImageContrast(Image &wave_function_sq_modulus
 
 	float original_defocus1 = ctf_for_fitting->GetDefocus1() ; // The defocus is returned in pixels, not Angstrom
 	float original_defocus2 = ctf_for_fitting->GetDefocus2();
-	float known_astigmatism = (original_defocus1 - original_defocus2) / 2.0f * pixel_size;
+	float known_astigmatism = (original_defocus1 - original_defocus2) * pixel_size; // ctffind defines astigmatism as the difference in defocus1 and defocus2
 	float known_astigmatism_angle = rad_2_deg(ctf_for_fitting->GetAstigmatismAzimuth());
 
 	wxPrintf("Astigmatism params are %3.3e %3.3e\n", known_astigmatism, known_astigmatism_angle);
@@ -888,8 +888,8 @@ void WaveFunctionPropagator::ReturnImageContrast(Image &wave_function_sq_modulus
 			myfile << std::to_string(myroundint(for_ctffind.defocus_step)) + "\n";
 			myfile << "yes\n"; // know astig?
 			myfile << "yes\n";
-			myfile << std::to_string(0) + "\n"; //astig
-			myfile << std::to_string(0) + "\n"; // ang
+			myfile << std::to_string(known_astigmatism) + "\n"; //astig
+			myfile << std::to_string(known_astigmatism_angle) + "\n"; // ang
 			myfile << "no\n"; // phase shift
 			myfile << do_tilt; // tilt
 			myfile << "yes\n"; // expert opt
@@ -1064,7 +1064,7 @@ void WaveFunctionPropagator::ReturnImageContrast(Image &wave_function_sq_modulus
     	float max_error = 0.01f;
     	if ( fabsf(fit_1) > fabsf(original_defocus1 * max_error))
     	{
-    		wxPrintf("The fit defocus (%f) is > %f percent which is probably fit issue, and not a random error in the apparent focal plane. The Amplitude contrast ratio is probably incorrect\n", max_error*100,pixel_size*fit_1);
+    		wxPrintf("The fit defocus error (%f angstrom) is > %f percent which is probably fit issue, and not a random error in the apparent focal plane. The Amplitude contrast ratio is probably incorrect\n", fit_1*pixel_size, fit_1/original_defocus1*100, max_error*100);
     	}
     	else
     	{


### PR DESCRIPTION
…litude contrast in wave_function_propagtor.cpp. TThe known_astigmatism used to make corrections to the defocus image prior to amplitude contrast estimation was wrong by a factor of 1/2.

The changes only affect simulation code
- simulator.cpp
- wave_function_propagator.cpp

B/c it is a algorithmic (as opposed to runtime/software function) bug, I will **not** push this change in to the long term maintenance branch releases/v1.1.0