### PR TITLE
Replace existing timing and add optional profiling timers to unblur i…

### DIFF
--- a/src/programs/unblur/unblur.cpp
+++ b/src/programs/unblur/unblur.cpp
@@ -6,6 +6,7 @@
 #ifdef HYPOTHETICAL_CONTROL_OVER_TIMING
 using namespace cistem_timer;
 #else
+#define PRINT_VERBOSE
 using namespace cistem_timer_noop;
 #endif
 


### PR DESCRIPTION
…n preparation for pre-gpu*ifying optimization to the CPU code.

## Goal: 
More specific timing options using the cistem stopwatch class for use in profiling and optimization.

## Summary:
- Existing timings are preserved, and always on, but only have 80 % code coverage.
- New profiling timer is under control of a macro define, but could be a configure option (--enable-timing or such)
  - If turned off, the cistem_timer_noop namespace is used, and the calls compile to noop and are optimized out (no code generated.)
 - Current bottlenecks are mostly as expected _**except the setup of the  exposure filter**_ takes **~17%** of the entire runtime. 

## Main Changes:

### Replace existing wxTiming with cistem_timer::unblur_timing

- the timing in place only has ~80% coverage for the total elapsed time. 
- this timer is always compiled on, since the cistem_timer namespace is explicitly referenced.

```code
		---------Timing Results---------

		Total elapsed                    : 00:02:11:093
		Total measured                   : 00:01:45:808    80.71% 
		read frames                      : 00:00:26:232    24.79% 
		initial refine                   : 00:00:00:153     0.15% 
		main refine                      : 00:00:00:318     0.30% 
		final refine                     : 00:01:19:104    74.76% 

		--------------------------------
```

### Optional profiling (zero cost when turned off)
```code
#define HYPOTHETICAL_CONTROL_OVER_TIMING
#ifdef HYPOTHETICAL_CONTROL_OVER_TIMING
using namespace cistem_timer;
#else
using namespace cistem_timer_noop;
#endif
```
### Add over all profiling

```code
		---------Timing Results---------

		Total elapsed                    : 00:02:11:359
		Total measured                   : 00:02:11:028    99.75% 
		allocate electron dose           : 00:00:00:000     0.00% 
		read in frames                   : 00:00:11:016     8.41% 
		dark correct                     : 00:00:01:226     0.94% 
		gain correct                     : 00:00:01:186     0.91% 
		replace outliers                 : 00:00:02:632     2.01% 
		forward FFT                      : 00:00:10:151     7.75% 
		make prebinned stack             : 00:00:00:117     0.09% 
		initial refine                   : 00:00:00:153     0.12% 
		main refine                      : 00:00:00:318     0.24% 
		apply shifts 1                   : 00:00:03:967     3.03% 
		final refine                     : 00:01:15:133    57.34% 
		setup dose filter                : 00:00:00:061     0.05% 
		calc dose filter                 : 00:00:21:779    16.62% 
		apply dose filter                : 00:00:01:380     1.05% 
		copy dose filter sum of squares  : 00:00:00:008     0.01% 
		final sum                        : 00:00:01:222     0.93% 
		restore power                    : 00:00:00:023     0.02% 
		write out sum image              : 00:00:00:305     0.23% 
		fill result                      : 00:00:00:000     0.00% 
		cleanup                          : 00:00:00:343     0.26% 

		--------------------------------

```

### Add a timer specific to the refinement method, as it is ~55% of total runtime

```code
		---------Timing Results---------

		Total elapsed                    : 00:01:15:599
		Total measured                   : 00:01:15:553    99.94% 
		allocate running average         : 00:00:00:000     0.00% 
		prepare initial sum              : 00:00:01:182     1.56% 
		prepare sum                      : 00:00:15:270    20.21% 
		compute cross correlation        : 00:00:42:629    56.42% 
		find peak                        : 00:00:03:626     4.80% 
		deallocate sum minus             : 00:00:00:011     0.01% 
		smooth shifts                    : 00:00:00:000     0.00% 
		shift image                      : 00:00:11:093    14.68% 
		cleanup                          : 00:00:00:000     0.00% 
		remake sum                       : 00:00:01:740     2.30% 


```

