### PR TITLE
Doubles speed of CalculateDoseFilterAs1DArray

### DIFF
--- a/src/core/electron_dose.cpp
+++ b/src/core/electron_dose.cpp
@@ -82,16 +82,16 @@ void ElectronDose::CalculateDoseFilterAs1DArray(Image *ref_image, float *filter_
   const float reduced_fourier_voxel_size = ref_image->fourier_voxel_size_x / pixel_size;
   // The spatial frequency is calculated as sqrt(x^2 + y^2 + z^2)/pixel_size.
   // To remove the sqrt call, we square the pixel size to move it inside, and then absorb the sqrt i.e. () ^ 1/2 into the exponent critical_dose_b -> critical_dose_b / 2
-  pixel_size *= pixel_size;
+  float pixel_size_sq = pixel_size * pixel_size;
 	for (k = 0; k <= ref_image->physical_upper_bound_complex_z; k++)
 	{
 		z = ref_image->ReturnFourierLogicalCoordGivenPhysicalCoord_Z(k) * ref_image->fourier_voxel_size_z;
-		z = (z*z/pixel_size);
+		z = (z*z/pixel_size_sq);
 
 		for (j = 0; j <= ref_image->physical_upper_bound_complex_y; j++)
 		{
 			y = ref_image->ReturnFourierLogicalCoordGivenPhysicalCoord_Y(j) * ref_image->fourier_voxel_size_y;
-			y = (y*y/pixel_size);
+			y = (y*y/pixel_size_sq);
 
 			for (i = 0; i <= ref_image->physical_upper_bound_complex_x; i++)
 			{
@@ -122,18 +122,18 @@ void ElectronDose::CalculateCummulativeDoseFilterAs1DArray(Image *ref_image, flo
   const float reduced_fourier_voxel_size = ref_image->fourier_voxel_size_x / pixel_size;
   // The spatial frequency is calculated as sqrt(x^2 + y^2 + z^2)/pixel_size.
   // To remove the sqrt call, we square the pixel size to move it inside, and then absorb the sqrt i.e. () ^ 1/2 into the exponent critical_dose_b -> critical_dose_b / 2
-  pixel_size *= pixel_size;
+  float pixel_size_sq = pixel_size * pixel_size;
 
 	for (k = 0; k <= ref_image->physical_upper_bound_complex_z; k++)
 	{
 		z = ref_image->ReturnFourierLogicalCoordGivenPhysicalCoord_Z(k) * ref_image->fourier_voxel_size_z;
-		z = (z*z/pixel_size);
+		z = (z*z/pixel_size_sq);
 
 
 		for (j = 0; j <= ref_image->physical_upper_bound_complex_y; j++)
 		{
 			y = ref_image->ReturnFourierLogicalCoordGivenPhysicalCoord_Y(j) * ref_image->fourier_voxel_size_y;
-			y = (y*y/pixel_size);
+			y = (y*y/pixel_size_sq);
 
 			for (i = 0; i <= ref_image->physical_upper_bound_complex_x; i++)
 			{

--- a/src/core/electron_dose.h
+++ b/src/core/electron_dose.h
@@ -8,6 +8,7 @@ public:
 	float critical_dose_a;
 	float critical_dose_b;
 	float critical_dose_c;
+  float reduced_critical_dose_b;
 
 	float voltage_scaling_factor;
 
@@ -29,7 +30,7 @@ public:
 
 inline float ElectronDose::ReturnCriticalDose(float spatial_frequency)
 {
-	return (critical_dose_a * powf(spatial_frequency, critical_dose_b) + critical_dose_c) * voltage_scaling_factor;
+	return (critical_dose_a * powf(spatial_frequency, reduced_critical_dose_b) + critical_dose_c) * voltage_scaling_factor;
 }
 
 


### PR DESCRIPTION
### Summary

Doubles speed by removing a sqrt and branching conditions on the inner loop.

### Relevance

In my testing on unblur, with a 75 frame K3 movie, including cleared caches/disk access, a full 17% of the runtime was due to the exposure filtering, in the CalculateDoseFilterAs1DArray. These changes cut this in half, which in absolute terms is > 3 cpu*hrs/1000 movies. 

### Tested for accuracy by

I took the cumulative difference between the new and original filter values, which are zero out to 6 decimal places.

### Deets

The sqrt is eliminated by incorporating it into the exponential  in ReturnCriticalDose, which also requires "pre" squaring the pixel size, resulting in both a reduced pixel size, and a reduced critical_dose_b. I added an aptly named parameter so that it would be clear to anyone looking at the code that there is a small modification to the formula in @timothygrant80 s paper.