### PR TITLE
Continuous building and testing using Github actions

### DIFF
--- a/.cicontainer/Dockerfile
+++ b/.cicontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM intel/oneapi-hpckit
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8 
+
+RUN apt-get --allow-releaseinfo-change update && \
+    apt-get install -y gtk2.0-dev \
+        fftw3-dev libtiff-dev software-properties-common libffi-dev \
+        libbz2-dev libsqlite3-dev zlib1g-dev libjpeg-dev libtiff-dev \
+        libreadline-dev liblzma-dev libssl-dev libncursesw5-dev
+
+#Need newer git for Github actions
+RUN add-apt-repository ppa:git-core/ppa -y && apt-get --allow-releaseinfo-change update && apt-get install -y git
+
+RUN wget -q https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5.tar.bz2 -O /tmp/wxwidgets.tar.bz2 && \
+    echo 'Installing wxWidgets' && \
+    tar -xf /tmp/wxwidgets.tar.bz2 -C /tmp && \
+    cd /tmp/wxWidgets-3.0.5  && \
+    CXX=/opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/icpc CC=/opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64/icc CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure --disable-precomp-headers --prefix=/usr/local --with-libnotify=no --disable-shared --without-gtkprint --with-libjpeg=builtin --with-libpng=builtin --with-libtiff=builtin --with-zlib=builtin --with-expat=builtin --disable-compat28 --without-liblzma --without-libjbig --with-gtk=2 --disable-sys-libs && \
+    make -j4 && \
+    make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: ICPC compile
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+    container: jojoelfe/cistem_ci
+    outputs:
+      version: ${{ steps.configure.outputs.version }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: regenerate_project
+      run: ./regenerate_project.b
+    - name: set path
+      run: | 
+        echo "/opt/intel/oneapi/compiler/2021.4.0/linux/bin/intel64" >> $GITHUB_PATH
+        echo "CPATH=/opt/intel/oneapi/vpl/2021.6.0/include:/opt/intel/oneapi/tbb/2021.4.0/env/../include:/opt/intel/oneapi/mpi/2021.4.0//include:/opt/intel/oneapi/mkl/2021.4.0/include:/opt/intel/oneapi/ippcp/2021.4.0/include:/opt/intel/oneapi/ipp/2021.4.0/include:/opt/intel/oneapi/dpl/2021.5.0/linux/include:/opt/intel/oneapi/dnnl/2021.4.0/cpu_dpcpp_gpu_dpcpp/lib:/opt/intel/oneapi/dev-utilities/2021.4.0/include:/opt/intel/oneapi/dal/2021.4.0/include:/opt/intel/oneapi/compiler/2021.4.0/linux/include:/opt/intel/oneapi/ccl/2021.4.0/include/cpu_gpu_dpcpp" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/opt/intel/oneapi/vpl/2021.6.0/lib:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mpi/2021.4.0//libfabric/lib:/opt/intel/oneapi/mpi/2021.4.0//lib/release:/opt/intel/oneapi/mpi/2021.4.0//lib:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/itac/2021.4.0/slib:/opt/intel/oneapi/ippcp/2021.4.0/lib/intel64:/opt/intel/oneapi/ipp/2021.4.0/lib/intel64:/opt/intel/oneapi/dnnl/2021.4.0/cpu_dpcpp_gpu_dpcpp/lib:/opt/intel/oneapi/debugger/10.2.4/gdb/intel64/lib:/opt/intel/oneapi/debugger/10.2.4/libipt/intel64/lib:/opt/intel/oneapi/debugger/10.2.4/dep/lib:/opt/intel/oneapi/dal/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/x64:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/emu:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/oclfpga/host/linux64/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/lib/oclfpga/linux64/lib:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/ccl/2021.4.0/lib/cpu_gpu_dpcpp" >> $GITHUB_ENV
+        echo "MKLROOT=/opt/intel/oneapi/mkl/2021.4.0" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=/opt/intel/oneapi/vtune/2021.7.1/include/pkgconfig/lib64:/opt/intel/oneapi/vpl/2021.6.0/lib/pkgconfig:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/pkgconfig:/opt/intel/oneapi/mpi/2021.4.0/lib/pkgconfig:/opt/intel/oneapi/mkl/2021.4.0/lib/pkgconfig:/opt/intel/oneapi/ippcp/2021.4.0/lib/pkgconfig:/opt/intel/oneapi/inspector/2021.4.0/include/pkgconfig/lib64:/opt/intel/oneapi/dpl/2021.5.0/lib/pkgconfig:/opt/intel/oneapi/dal/2021.4.0/lib/pkgconfig:/opt/intel/oneapi/compiler/2021.4.0/lib/pkgconfig:/opt/intel/oneapi/ccl/2021.4.0/lib/pkgconfig:/opt/intel/oneapi/advisor/2021.4.0/include/pkgconfig/lib64:" >> $GITHUB_ENV
+        echo "LIBRARY_PATH=/opt/intel/oneapi/vpl/2021.6.0/lib:/opt/intel/oneapi/tbb/2021.4.0/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mpi/2021.4.0//libfabric/lib:/opt/intel/oneapi/mpi/2021.4.0//lib/release:/opt/intel/oneapi/mpi/2021.4.0//lib:/opt/intel/oneapi/mkl/2021.4.0/lib/intel64:/opt/intel/oneapi/ippcp/2021.4.0/lib/intel64:/opt/intel/oneapi/ipp/2021.4.0/lib/intel64:/opt/intel/oneapi/dnnl/2021.4.0/cpu_dpcpp_gpu_dpcpp/lib:/opt/intel/oneapi/dal/2021.4.0/lib/intel64:/opt/intel/oneapi/compiler/2021.4.0/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2021.4.0/linux/lib:/opt/intel/oneapi/clck/2021.4.0/lib/intel64:/opt/intel/oneapi/ccl/2021.4.0/lib/cpu_gpu_dpcpp" >> $GITHUB_ENV
+        echo "NLSPATH=/opt/intel/oneapi/mkl/2021.4.0/lib/intel64/locale/%l_%t/%N" >> $GITHUB_ENV
+    - name: configure
+      run: |
+        mkdir -p build/icpc 
+        cd build/icpc 
+        CXX=icpc CC=icc ../../configure  --enable-experimental --enable-staticmode --enable-openmp  --with-wx-config=wx-config  --enable-samples
+        VERSION=$(cat config.log | grep CISTEM_VERSION_TEXT | cut -d' ' -f3 | tr -d '"')
+        echo "::set-output name=version::$VERSION" 
+    - name: make
+      run: |
+        cd build/icpc
+        make -j4
+    - name: clean up
+      run: |
+        cd build/icpc
+        rm -r src/core
+        rm -r src/gui
+        rm -r src/programs
+    - name: Create binary artifact
+      uses: actions/upload-artifact@v2
+      with: 
+        name: cistem_binaries
+        path: build/icpc/src
+
+  console_test:
+    name: Console test
+    needs: build
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: cistem_binaries
+    - name: test console_test
+      continue-on-error: true
+      run: |
+        chmod +x console_test
+        ./console_test 
+    - name: Create image artifact
+      uses: actions/upload-artifact@v2
+      with: 
+        name: test_images
+        path: /tmp/*.mrc
+
+  samples_functional_testing:
+    name: Samples functional testing
+    needs: build
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: cistem_binaries
+    - name: test samples_functional_testing
+      continue-on-error: true
+      run: |
+        chmod +x samples_functional_testing
+        ./samples_functional_testing
+

--- a/src/programs/samples/samples_functional_testing.cpp
+++ b/src/programs/samples/samples_functional_testing.cpp
@@ -2,7 +2,9 @@
 
 #include "../../core/core_headers.h"
 #include "0_Simple/disk_io_image.cpp"
+#ifdef ENABLEGPU
 #include "1_GPU_comparison/cpu_vs_gpu.cpp"
+#endif
 
 #include "classes/TestFile.cpp"
 #include "classes/EmbeddedTestFile.cpp"


### PR DESCRIPTION
This will enable automated building and testing of cisTEM using Github actions. In its current form it will be triggered by commits or PRs onto the master branch. cisTEM will be compiled using the intel compiler on a Ubuntu 18.0 system, without any CUDA coda (yet). The resulting binaries are then packaged into an archive that can be downloaded in the `Actions `tab of the repository. The workflow will then run `console_test` and `samples_functional_testing` on a Ubuntu 18.0 machine without intel compiler/libraries installed to ensure the compile worked and is statically linked. 

While the main purpose at the moment is automated testing and allowing reviewers to quickly test the binaries, in the future this could be used to create experimental builds for internal use or by collaborators. I'm open for suggestions what the best build environments would be. We could for example try to create a container based on centOS 6/7 for maximal compatibility.

