### PR TITLE
Expand console test to validate methods needed for new tests. 

### DIFF
--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -513,6 +513,12 @@ inline bool FloatsAreAlmostTheSame(float a, float b)
 	return (fabs(a-b) < 0.0001);
 }
 
+template <typename T>
+inline bool RelativeErrorIsLessThanEpsilon(T reference, T test_value, T epsilon = 0.0001)
+{
+  return (std::abs( (reference-test_value) / reference ) < epsilon);
+}
+
 inline bool InputIsATerminal()
 {
    return isatty(fileno(stdin));


### PR DESCRIPTION

# Description

Adds EmpiricalDistribution and ReturnSumOfSquares (real and Fourier) to console test as these methods will be needed to validate more complicated tests later on. A new comparison method to calculate the relative error is also added because FloatsAreAlmostTheSame will return false when both inputs are scaled by a large number even if they would have passed being small. (it ignores significant figures)

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [X] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [X] core library
- [ ] gpu core library
- [X] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [X] Tested manually from CLI
- [X] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
