### PR TITLE
Enable rotation in template matching by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,22 +183,29 @@ AC_ARG_ENABLE(debugmode, AS_HELP_STRING([--enable-debugmode],[Compile in debug m
   	
 if test "$want_cuda" = "yes" ; then
 
-	# ~Runtime about 85% with K3 images, but mips are different - total detection is ~the same, but needs more investigation.
-	# Disabling by default so that the code matches what Bronwyn used in the 2D vs 3DTM paper (for reproducibility.)
-	AC_ARG_ENABLE(rotated-tm, AS_HELP_STRING([--enable-rotated-tm],[Place power of 2 sized axis on X by rotating 90 deg in template matching for speed [default=no]]),[
-	  if test "$enableval" = yes; then
-	  CPPFLAGS="$CPPFLAGS -DROTATEFORSPEED"
-	  CXXFLAGS="$CXXFLAGS -DROTATEFORSPEED"
+	# ~Runtime about 85% with K3 images, but mips are different - total detection is ~the same. 
+  # Determined this is likely just numerical error. Enabling by default.
+  #  --disable-feature is equivalent to --enable-feature=no. 
+  use_rotated_tm=1
+	AC_ARG_ENABLE(rotated-tm, AS_HELP_STRING([--disable-rotated-tm],[Place power of 2 sized axis on X by rotating 90 deg in template matching for speed [default=no]]),[
+	  if test "$enableval" = no; then
+      use_rotated_tm=0
 	  fi
 	  ])
-		
-    AC_MSG_NOTICE([Adding the CUDA includes Setting up NVCC initial flags])
-    CUDA_CPPFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
-    CUDA_CXXFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
-    CXXFLAGS="$CXXFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
-    CPPFLAGS="$CPPFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
-    AC_MSG_NOTICE([Using CUDA_CXXFLAGS=$CUDA_CXXFLAGS])
-    AC_MSG_NOTICE([Using CUDA_LIBS=$CUDA_LIBS])
+
+  if test "x$use_rotated_tm" = "x1"; then
+    CPPFLAGS="$CPPFLAGS -DROTATEFORSPEED"
+    CXXFLAGS="$CXXFLAGS -DROTATEFORSPEED"
+    AC_MSG_NOTICE([Enabling rotated-tm]);
+  fi
+
+  AC_MSG_NOTICE([Adding the CUDA includes Setting up NVCC initial flags])
+  CUDA_CPPFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
+  CUDA_CXXFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
+  CXXFLAGS="$CXXFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
+  CPPFLAGS="$CPPFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
+  AC_MSG_NOTICE([Using CUDA_CXXFLAGS=$CUDA_CXXFLAGS])
+  AC_MSG_NOTICE([Using CUDA_LIBS=$CUDA_LIBS])
 fi
 
 ##############################

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,7 @@ if test "$want_cuda" = "yes" ; then
   AC_MSG_NOTICE([Adding the CUDA includes Setting up NVCC initial flags])
   CUDA_CPPFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
   CUDA_CXXFLAGS="$CUDA_CFLAGS $NVCCFLAGS"
+  
   CXXFLAGS="$CXXFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
   CPPFLAGS="$CPPFLAGS -DENABLEGPU $use_gpu_cache_hints $CUDA_CFLAGS"
   AC_MSG_NOTICE([Using CUDA_CXXFLAGS=$CUDA_CXXFLAGS])

--- a/src/core/ctf.cpp
+++ b/src/core/ctf.cpp
@@ -530,7 +530,7 @@ float CTF::PhaseShiftGivenBeamTiltAndShift(float squared_spatial_frequency, floa
 	float spatial_frequency = sqrtf(squared_spatial_frequency);
 	float phase_shift = 2.0f * PIf * spherical_aberration * squared_wavelength * squared_spatial_frequency * spatial_frequency * beam_tilt;
 	phase_shift -= 2.0f * PIf * spatial_frequency * particle_shift;
-	return clamp_angular_range(phase_shift);
+	return clamp_angular_range_negative_pi_to_pi(phase_shift);
 
 }
 

--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -435,7 +435,21 @@ inline float deg_2_rad(float degrees)
   return degrees * PIf / 180.;
 }
 
-inline float clamp_angular_range(float angle, bool units_are_degrees = false)
+inline float clamp_angular_range_0_to_2pi(float angle, bool units_are_degrees = false)
+{
+	// Clamps the angle to be in the range ( 0,+360 ] { exclusive, inclusive }
+	if (units_are_degrees)
+	{
+		angle = fmodf(angle, 360.0f);
+	}
+	else
+	{
+		angle = fmodf(angle, 2.0f * PIf);
+	}
+	return angle;
+}
+
+inline float clamp_angular_range_negative_pi_to_pi(float angle, bool units_are_degrees = false)
 {
 	// Clamps the angle to be in the range ( -180,+180 ] { exclusive, inclusive }
 	if (units_are_degrees)

--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -11104,8 +11104,9 @@ void Image::Rotate2DInPlaceBy90Degrees(bool rotate_by_positive_90_degrees)
 {
 	// Rotate without interpolation by swapping indices.
 	Image buffer_image;
-	buffer_image.Allocate(logical_y_dimension, logical_x_dimension, true);
+	buffer_image.Allocate(logical_y_dimension, logical_x_dimension, logical_z_dimension, true);
 	long current_address_old_image = 0;
+ 	int k;
 	int y_new = -1;
 	int x_new = -1;
 	int y_old = 0;
@@ -11114,29 +11115,35 @@ void Image::Rotate2DInPlaceBy90Degrees(bool rotate_by_positive_90_degrees)
 	// Negative rotation is clockwise looking down the image normal (Y --> X)
 	if (rotate_by_positive_90_degrees)
 	{
-		for (y_old = 0 ; y_old < logical_y_dimension; y_old ++)
-		{
-			x_new = logical_y_dimension - y_old - 1;
+    for (k = 0 ; k < logical_z_dimension; k++)
+    {
+      for (y_old = 0 ; y_old < logical_y_dimension; y_old++)
+      {
+        x_new = logical_y_dimension - y_old - 1;
 
-			for (x_old = 0; x_old < logical_x_dimension; x_old++)
-			{
-				y_new = x_old;
-				buffer_image.real_values[buffer_image.ReturnReal1DAddressFromPhysicalCoord(x_new,y_new,0)] = ReturnRealPixelFromPhysicalCoord(x_old,y_old,0);
-			}
-		}
+        for (x_old = 0; x_old < logical_x_dimension; x_old++)
+        {
+          y_new = x_old;
+          buffer_image.real_values[buffer_image.ReturnReal1DAddressFromPhysicalCoord(x_new,y_new,k)] = ReturnRealPixelFromPhysicalCoord(x_old,y_old,k);
+        }
+      }
+    }
 	}
 	else
 	{
-		for (y_old = 0 ; y_old < logical_y_dimension; y_old ++)
-		{
-			x_new = y_old;
-			for (x_old = 0; x_old < logical_x_dimension; x_old++)
-			{
-				y_new = logical_x_dimension - x_old - 1;
-				buffer_image.real_values[buffer_image.ReturnReal1DAddressFromPhysicalCoord(x_new,y_new,0)] = ReturnRealPixelFromPhysicalCoord(x_old,y_old,0);
-			}
+    for (k = 0 ; k < logical_z_dimension; k++)
+    {    
+      for (y_old = 0 ; y_old < logical_y_dimension; y_old++)
+      {
+        x_new = y_old;
+        for (x_old = 0; x_old < logical_x_dimension; x_old++)
+        {
+          y_new = logical_x_dimension - x_old - 1;
+          buffer_image.real_values[buffer_image.ReturnReal1DAddressFromPhysicalCoord(x_new,y_new,k)] = ReturnRealPixelFromPhysicalCoord(x_old,y_old,k);
+        }
 
-		}
+      }
+    }
 	}
 	Consume(&buffer_image);
 }

--- a/src/core/pdb.cpp
+++ b/src/core/pdb.cpp
@@ -851,7 +851,7 @@ void PDB::TransformLocalAndCombine(PDB *pdb_ensemble, int number_of_pdbs, int fr
 					// If we have more than one noise particle, enforce non-overlap
 					if (iPart == 0)
 					{
-						offset_angle = clamp_angular_range(my_rand.GetUniformRandomSTD(-PIf,PIf));
+						offset_angle = clamp_angular_range_negative_pi_to_pi(my_rand.GetUniformRandomSTD(-PIf,PIf));
 						non_overlaping_particle_found = true;
 						occupied_sectors[0] = offset_angle;
 					}
@@ -863,7 +863,7 @@ void PDB::TransformLocalAndCombine(PDB *pdb_ensemble, int number_of_pdbs, int fr
 						while (is_too_close && iTry < max_tries)
 						{
 							iTry += 1;
-							offset_angle = clamp_angular_range(my_rand.GetUniformRandomSTD(-PIf,PIf));
+							offset_angle = clamp_angular_range_negative_pi_to_pi(my_rand.GetUniformRandomSTD(-PIf,PIf));
 							float dx = cosf(offset_angle);
 							float dy = sinf(offset_angle);
 							float ang_diff;

--- a/src/gui/MyOverviewPanel.cpp
+++ b/src/gui/MyOverviewPanel.cpp
@@ -153,6 +153,30 @@ void MyOverviewPanel::SetWelcomeInfo()
 	InfoText->Newline();
 #endif
 
+// If compiled with debug and any other special configure flags are set, display them here
+#ifdef DEBUG
+  InfoText->WriteText(wxString::Format("Compiled in DEBUG mode with additional configure flags: "));
+  #ifdef ENABLEGPU
+    InfoText->WriteText(wxString::Format("ENABLEGPU "));
+  #endif
+  #ifdef MKL
+    InfoText->WriteText(wxString::Format("MKL "));
+  #endif
+  #ifdef EXPERIMENTAL
+    InfoText->WriteText(wxString::Format("EXPERIMENTAL "));
+  #endif
+  #ifdef RIGOROUS_SOCKET_CHECK
+    InfoText->WriteText(wxString::Format("RIGOROUS_SOCKET_CHECK "));
+  #endif
+  #ifdef ENABLESAMPLES
+    InfoText->WriteText(wxString::Format("ENABLESAMPLES "));
+  #endif
+  #ifdef ROTATEFORSPEED
+    InfoText->WriteText(wxString::Format("ROTATEFORSPEED "));
+  #endif
+  InfoText->Newline();
+#endif
+
 	InfoText->Newline();
 	InfoText->Newline();
 	InfoText->EndFontSize();

--- a/src/gui/MyOverviewPanel.cpp
+++ b/src/gui/MyOverviewPanel.cpp
@@ -174,6 +174,9 @@ void MyOverviewPanel::SetWelcomeInfo()
   #ifdef ROTATEFORSPEED
     InfoText->WriteText(wxString::Format("ROTATEFORSPEED "));
   #endif
+  #ifdef PROFILING
+    InfoText->WriteText(wxString::Format("Compiled in PROFILING mode"));
+  #endif
   InfoText->Newline();
 #endif
 

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -1162,6 +1162,8 @@ bool MatchTemplateApp::DoCalculation()
 		best_psi.Rotate2DInPlaceBy90Degrees(false);
 		// To account for the pre-rotation, psi needs to have 90 added to it.
 		best_psi.AddConstant(90.0f);
+		// We also want the angles to remain in (0,360] so loop over and clamp
+		for (int idx = 0; idx < best_psi.real_memory_allocated; idx++) { best_psi.real_values[idx] = clamp_angular_range(best_psi.real_values[idx], true); }
 		best_theta.Rotate2DInPlaceBy90Degrees(false);
 		best_phi.Rotate2DInPlaceBy90Degrees(false);
 		best_defocus.Rotate2DInPlaceBy90Degrees(false);

--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -1163,7 +1163,7 @@ bool MatchTemplateApp::DoCalculation()
 		// To account for the pre-rotation, psi needs to have 90 added to it.
 		best_psi.AddConstant(90.0f);
 		// We also want the angles to remain in (0,360] so loop over and clamp
-		for (int idx = 0; idx < best_psi.real_memory_allocated; idx++) { best_psi.real_values[idx] = clamp_angular_range(best_psi.real_values[idx], true); }
+		for (int idx = 0; idx < best_psi.real_memory_allocated; idx++) { best_psi.real_values[idx] = clamp_angular_range_0_to_2pi(best_psi.real_values[idx], true); }
 		best_theta.Rotate2DInPlaceBy90Degrees(false);
 		best_phi.Rotate2DInPlaceBy90Degrees(false);
 		best_defocus.Rotate2DInPlaceBy90Degrees(false);


### PR DESCRIPTION
# Description

Enables rotation of images in match_template by default (may still configure --disable-rotated-dm). For K3s with the long dimension on X, this is runs in 85% on a V100 and 79.5% on RTX3090"

Fixes no issue, this is a performance enhancement.

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [X] no The previous PR merged into the master is isolated to include/gemmi, so this is okay, no conflicts.

# Which compilers were tested

- [ ] g++
- [X] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [X] core library
- [ ] gpu core library
- [X] program it modifies

# How has the functionality been tested?

I ran TM on three "standard" yeast images. The peak heights were all a bit different as expected, given the order of the 1D FFTs along X and Y are swapped, which should produce some variability in where the noise accumulates due to floating point erros.

**Total peaks found** Net 1 more peak in the rotated. 
| Non-Rotated | Rotated |
| --- | --- |
|55|48|
|305|308|
|300|305|

**Total run time on 2x RTX 3090**
| Non-Rotated | Rotated |
| --- | --- |
|181 min| 122 min|

- [X] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
  - I removed some old comments and added a print guard to limit to threadIDX == 0 in match_template for some diagnostic prints. These are not necessary but improve readability.
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [X] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
