### PR TITLE
On my GCC console test will not compile with this header. It seems

### DIFF
--- a/src/programs/console_test/console_test.cpp
+++ b/src/programs/console_test/console_test.cpp
@@ -2,6 +2,7 @@
 #include <wx/app.h>
 #include <wx/cmdline.h>
 #include <cstdio>
+#include <unordered_map>
 #include "wx/socket.h"
 
 #include "../../core/core_headers.h"


### PR DESCRIPTION
adding this header should not break other compilers so I think it should
be added.

# Description

Please include a summary of the change and which issue is fixed. Please also include **relevant motivation** and context. It is usually easy to see what you are doing, so please be thoughtful with explaining *Why* you are doing it!

My GCC won't compile without adding the <unordered_map> header to console_test.  My intel still compiles so I hope it is ok to add for everyone.

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [x] no

# Which compilers were tested

- [x] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [x] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
