### PR TITLE
Enables cuda toolkit vs 11.6, which no longer compiles samples code. …

### DIFF
--- a/.vscode_shared/BenHimes/tasks.json
+++ b/.vscode_shared/BenHimes/tasks.json
@@ -4,7 +4,7 @@
     "version": "2.0.0",
     "options": {
         "env": {
-            "cuda_dir": "/groups/cryoadmin/software/CUDA-TOOLKIT/cuda_11.3.1",
+            "cuda_dir": "/groups/cryoadmin/software/CUDA-TOOLKIT/cuda_11.6.0",
             "wx_dir":"/groups/cryoadmin/software/WX/wx_static_3.05_",
             "build_dir": "${workspaceFolder}/build",
             "compile_cores": "48"

--- a/src/core/core_headers.h
+++ b/src/core/core_headers.h
@@ -192,11 +192,6 @@ protected:
 #include <nppi_arithmetic_and_logical_operations.h>
 #include <nppi_statistics_functions.h>
 #include <npps_arithmetic_and_logical_operations.h>
-#include <helper_functions.h>
-#include <helper_cuda.h>
-#include <thrust/transform_reduce.h>
-#include <thrust/device_vector.h>
-#include <thrust/functional.h>
 #include <typeinfo>
 #include <limits>
 


### PR DESCRIPTION
…This required removing helper_functions.h and helper_cuda, which are no longer needed anyway (previously used in cudaErr macro) Also cleaned oout unused thrust headers while at it.

# Description

In addition to the removal of unused headers, some of which are no longer available, there are small changes to match_template.
- When the search image is rotated, the astigmatism angle should also be changed as the PS is rotated. I've included this in the block where the image is rotated. Scores improve and detection rates better match the unrotated search, indicating blurring from the errant CTF may have been a part of the difference. This is consistent with observations that our forward model is still not good enough.
-  There are a few other re-arrangements in place from my testing of also rotating the template by 90*. I've elected to leave these, even though they are not compiled, since I think it is the right thing to do eventually.


Fixes # (issue)

None 
# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [X] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [X] core library
- [ ] gpu core library
- [X] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested manually from GUI
- [X] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
