### PR TITLE
Adds CLI flag --is-alpha-fold-prediction to the simulator

### DIFF
--- a/src/core/pdb.cpp
+++ b/src/core/pdb.cpp
@@ -62,10 +62,10 @@ PDB::PDB( long number_of_non_water_atoms, float cubic_size, float wanted_pixel_s
           float wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
           float wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
           float wanted_tilt_angle_to_emulate,
-          bool shift_by_center_of_mass)
-{
+          bool shift_by_center_of_mass,
+          bool is_alpha_fold_prediction) {
 
-	input_file_stream = NULL;
+    input_file_stream = NULL;
 	input_text_stream = NULL;
 	output_file_stream = NULL;
 	output_text_stream = NULL;
@@ -77,6 +77,7 @@ PDB::PDB( long number_of_non_water_atoms, float cubic_size, float wanted_pixel_s
 	this->cubic_size = cubic_size;
 
 	this->use_provided_com = false;
+    this->is_alpha_fold_prediction = is_alpha_fold_prediction;
 
 
 	this->MIN_PADDING_XY = minimum_paddeding_x_and_y;
@@ -108,7 +109,8 @@ PDB::PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, lo
 		float wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
 		float wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
 		float wanted_tilt_angle_to_emulate,
-    bool shift_by_center_of_mass)
+    bool shift_by_center_of_mass,
+    bool is_alpha_fold_prediction)
 {
 	input_file_stream = NULL;
 	input_text_stream = NULL;
@@ -116,6 +118,7 @@ PDB::PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, lo
 	output_text_stream = NULL;
 
 	this->use_provided_com = false;
+    this->is_alpha_fold_prediction = is_alpha_fold_prediction;
 
 	this->MIN_PADDING_XY = minimum_paddeding_x_and_y;
 	this->MIN_THICKNESS  = minimum_thickness_z;
@@ -141,7 +144,7 @@ PDB::PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, lo
 	Open(Filename, wanted_access_type, wanted_records_per_line);
 }
 
-PDB::PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, long wanted_records_per_line, int minimum_paddeding_x_and_y, double minimum_thickness_z, double *COM)
+PDB::PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, long wanted_records_per_line, int minimum_paddeding_x_and_y, double minimum_thickness_z, double *COM, bool is_alpha_fold_prediction)
 {
 	input_file_stream = NULL;
 	input_text_stream = NULL;
@@ -152,6 +155,7 @@ PDB::PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, lo
 	this->MIN_THICKNESS  = minimum_thickness_z;
 
 	this->use_provided_com = true;
+    this->is_alpha_fold_prediction = is_alpha_fold_prediction;
 
 	for (int iCOM = 0; iCOM < 3; iCOM++)
 	{
@@ -384,7 +388,15 @@ void PDB::Init()
 									my_atoms.Item(current_atom_number).y_coordinate = float(atom.pos.y);
 									my_atoms.Item(current_atom_number).z_coordinate = float(atom.pos.z);
 									my_atoms.Item(current_atom_number).occupancy = atom.occ;
-									my_atoms.Item(current_atom_number).bfactor = atom.b_iso;
+                                    if (is_alpha_fold_prediction) {
+                                        // Convert the confidence score to a bfactor. The formula is adhoc.
+                                        // Confidence score is 0->100 with higher being more confident. 
+                                        my_atoms.Item(current_atom_number).bfactor = 4.f + powf(100.f - atom.b_iso,1.314159f);
+                                        // wxPrintf("Confidence score %f, bfactor %f\n",atom.b_iso,my_atoms.Item(current_atom_number).bfactor);
+                                    }
+                                    else {
+									    my_atoms.Item(current_atom_number).bfactor = atom.b_iso;
+                                    }
 
 
 

--- a/src/core/pdb.h
+++ b/src/core/pdb.h
@@ -95,15 +95,15 @@ class PDB {
 				float wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
 				float wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
 				float emulate_tilt_angle,
-        bool shift_by_center_of_mass);
+        bool shift_by_center_of_mass, bool is_alpha_fold_prediction);
 		PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, long wanted_records_per_line, int minimum_paddeding_x_and_y, double minimum_thickness_z,
 			int max_number_of_noise_particles,
 			float wanted_noise_particle_radius_as_mutliple_of_particle_radius,
 			float wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
 			float wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
 			float emulate_tilt_angle,
-      bool shift_by_center_of_mass);
-		PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, long wanted_records_per_line, int minimum_paddeding_x_and_y, double minimum_thickness_z, double *center_of_mass);
+      bool shift_by_center_of_mass, bool is_alpha_fold_prediction);
+		PDB(wxString Filename, long wanted_access_type, float wanted_pixel_size, long wanted_records_per_line, int minimum_paddeding_x_and_y, double minimum_thickness_z, double *center_of_mass, bool is_alpha_fold_prediction);
 
 		~PDB();
 
@@ -116,6 +116,7 @@ class PDB {
 		int records_per_line;
 		double center_of_mass[3];
 		bool use_provided_com;
+        bool is_alpha_fold_prediction;
 
 		int number_of_particles_initialized;
 		long number_of_each_atom[NUMBER_OF_ATOM_TYPES];

--- a/src/programs/simulate/scattering_potential.cpp
+++ b/src/programs/simulate/scattering_potential.cpp
@@ -28,7 +28,8 @@ void ScatteringPotential::InitPdbEnsemble(float wanted_pixel_size, bool shift_by
                                           float wanted_noise_particle_radius_as_mutliple_of_particle_radius,
                                           float wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
                                           float wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
-                                          float wanted_tilt_angle_to_emulate)
+                                          float wanted_tilt_angle_to_emulate,
+                                          bool is_alpha_fold_prediction)
 {
 
 	// backwards compatible with tigress where everything is double (ints would make more sense here.)
@@ -48,7 +49,8 @@ void ScatteringPotential::InitPdbEnsemble(float wanted_pixel_size, bool shift_by
                                 wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
                                 wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
                                 wanted_tilt_angle_to_emulate,
-                                shift_by_cetner_of_mass);
+                                shift_by_cetner_of_mass, 
+                                is_alpha_fold_prediction);
 	}
 }
 

--- a/src/programs/simulate/scattering_potential.h
+++ b/src/programs/simulate/scattering_potential.h
@@ -35,7 +35,8 @@ public:
                         float wanted_noise_particle_radius_as_mutliple_of_particle_radius,
                         float wanted_noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
                         float wanted_noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
-                        float wanted_tilt_angle_to_emulate);
+                        float wanted_tilt_angle_to_emulat,
+                        bool is_alpha_fold_prediction);
 	long ReturnTotalNumberOfNonWaterAtoms();
 
 

--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -658,6 +658,7 @@ class SimulateApp : public MyApp
 	float wgt = 0.0f;
 	float bf = 0.0f;
 	bool water_shell_only = false;
+    bool is_alpha_fold_prediction = false;
 	///////////
 	/////////////////////////////////////////
 
@@ -739,6 +740,7 @@ void SimulateApp::AddCommandLineOptions()
 	command_line_parser.AddOption("","wgt","Maximum number of neighboring noise particles when simulating an image stack. Default is 0",wxCMD_LINE_VAL_DOUBLE);
 	command_line_parser.AddOption("","bf","Maximum number of neighboring noise particles when simulating an image stack. Default is 0",wxCMD_LINE_VAL_DOUBLE);
 	command_line_parser.AddLongSwitch("water-shell-only","when adding constant background, taper off 4 Ang into the water");
+    command_line_parser.AddLongSwitch("is-alpha-fold-prediction", "Is this a alpha-fold prediction? If so, convert the confidence score stored in the bfactor column to a bfactor. default is no");
 
 //	command_line_parser.AddOption("j","","Desired number of threads. Overrides interactive user input. Is overriden by env var OMP_NUM_THREADS",wxCMD_LINE_VAL_NUMBER);
 }
@@ -817,6 +819,7 @@ void SimulateApp::DoInteractiveUserInput()
 	if (command_line_parser.Found("wgt", &temp_double)) { wgt = (float)temp_double;}
 	if (command_line_parser.Found("bf", &temp_double)) { bf = (float)temp_double;}
 	if (command_line_parser.Found("water-shell-only")) water_shell_only = true;
+    if (command_line_parser.Found("is-alpha-fold-prediction")) is_alpha_fold_prediction = true;
 
   if (DO_CROSSHAIR) DO_SOLVENT = false;
 	UserInput *my_input = new UserInput("Simulator", 0.25);
@@ -1046,7 +1049,7 @@ bool SimulateApp::DoCalculation()
                         noise_particle_radius_as_mutliple_of_particle_radius,
                         noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
                         noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
-                        emulate_tilt_angle
+                        emulate_tilt_angle,is_alpha_fold_prediction
                         );
 
 	}
@@ -1059,7 +1062,7 @@ bool SimulateApp::DoCalculation()
                         noise_particle_radius_as_mutliple_of_particle_radius,
                         noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
                         noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
-                        emulate_tilt_angle
+                        emulate_tilt_angle, is_alpha_fold_prediction
                         );
 	}
 
@@ -1436,7 +1439,7 @@ void SimulateApp::probability_density_2d(PDB *pdb_ensemble, int time_step)
 							noise_particle_radius_randomizer_lower_bound_as_praction_of_particle_radius,
 							noise_particle_radius_randomizer_upper_bound_as_praction_of_particle_radius,
 							emulate_tilt_angle,
-              SHIFT_BY_CENTER_OF_MASS);
+              SHIFT_BY_CENTER_OF_MASS, is_alpha_fold_prediction);
 
 	timer.lap("Init H20 & Spec");
 


### PR DESCRIPTION
# Description

The alpha fold confidence score runs from zero to 100, and is stored in the bfactor column in the pdb. If this flag (--is-alpha-fold-prediction) is passed to "simulate" then the score is converted as 
```math
powf((100.f - confidence_score), 1.314)
```
The form is chosen to penalize lower scores more, but is really just out of thin air.

Fixes nothing.

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [X] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [X] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [X] other (please specify)
**Also tested the output in template matching in the gui.**

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
