### PR TITLE
makes TM programs actually use the same border definition - fixes mis…

### DIFF
--- a/src/gui/MatchTemplateResultsPanel.cpp
+++ b/src/gui/MatchTemplateResultsPanel.cpp
@@ -13,6 +13,7 @@ MatchTemplateResultsPanel::MatchTemplateResultsPanel(wxWindow* parent)
 
     per_row_asset_id       = NULL;
     per_row_array_position = NULL;
+    template_match_job_ids = NULL;
     number_of_assets       = 0;
 
     selected_row     = -1;
@@ -141,8 +142,9 @@ void MatchTemplateResultsPanel::FillBasedOnSelectCommand(wxString wanted_command
     }
     // cache the various  alignment_job_ids
 
-    if ( template_match_job_ids != NULL )
+    if ( template_match_job_ids != NULL ) {
         delete[] template_match_job_ids;
+    }
     template_match_job_ids = new long[number_of_template_match_ids];
 
     main_frame->current_project.database.GetUniqueTemplateMatchIDs(template_match_job_ids, number_of_template_match_ids);

--- a/src/programs/prepare_stack_matchtemplate/prepare_stack_matchtemplate.cpp
+++ b/src/programs/prepare_stack_matchtemplate/prepare_stack_matchtemplate.cpp
@@ -203,7 +203,7 @@ bool MakeParticleStack::DoCalculation( ) {
         if ( ! read_coordinates ) {
             // look for a peak..
 
-            current_peak = mip_image.FindPeakWithIntegerCoordinates(0.0, FLT_MAX, box_size / 2 + 1);
+            current_peak = mip_image.FindPeakWithIntegerCoordinates(0.0, FLT_MAX, box_size / cistem::fraction_of_box_size_to_exclude_for_border + 1);
             if ( current_peak.value < wanted_threshold )
                 break;
 

--- a/src/programs/refine_template/refine_template.cpp
+++ b/src/programs/refine_template/refine_template.cpp
@@ -552,7 +552,8 @@ bool RefineTemplateApp::DoCalculation( ) {
     while ( current_peak.value >= wanted_threshold ) {
         // look for a peak..
 
-        current_peak = best_scaled_mip.FindPeakWithIntegerCoordinates(0.0, FLT_MAX, 50);
+        current_peak = best_scaled_mip.FindPeakWithIntegerCoordinates(0.0, FLT_MAX,
+                                                                      input_reconstruction_file.ReturnXSize( ) / cistem::fraction_of_box_size_to_exclude_for_border + 1);
         if ( current_peak.value < wanted_threshold )
             break;
         found_peaks[number_of_peaks_found] = current_peak;


### PR DESCRIPTION
…sing NULL assignment in constructor of MatchTemplateResultsPanel

# Description

Not setting the pointer to NULL in the constructor was causing a later check on if ! NULL to fail. 

There are *two* problems with this:
1) the conditional is meant to prevent problems by deleting an empty pointer, but delete [] already does nothing if the pointer is NULL
2) To prevent this sort of thing, I suggest we switch to value initialization, which then sets the pointer to NULL at the place of assignment, rather than in another file.
e.g.
rather than
```c++
file.h
void* ptr;
file.cpp
ptr = NULL;
```
just
```c++
file.h
void* ptr {};
```
we could be more explicit, but maybe this is overhead for this option?
```c++
void* ptr { nullptr };
```

I suggest we replace (only for pointers already being set null in constructors) 

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
