### PR TITLE
move OnHeaderClick out of class scope and into file scope so it may o…

### DIFF
--- a/src/gui/MatchTemplateResultsPanel.cpp
+++ b/src/gui/MatchTemplateResultsPanel.cpp
@@ -2,9 +2,15 @@
 #include "../core/cistem_constants.h"
 #include "../core/gui_core_headers.h"
 
-extern MyMainFrame*       main_frame;
-extern MyImageAssetPanel* image_asset_panel;
-extern MyMovieAssetPanel* movie_asset_panel;
+extern MyMainFrame*        main_frame;
+extern MyImageAssetPanel*  image_asset_panel;
+extern MyMovieAssetPanel*  movie_asset_panel;
+extern MatchTemplatePanel* match_template_panel;
+
+static void OnHeaderClick( ) {
+    // Rather than access members directly, create a method in MatchTemplatePanel to do this stuff.
+    match_template_panel->CheckForUnfinishedWork(true, false);
+}
 
 MatchTemplateResultsPanel::MatchTemplateResultsPanel(wxWindow* parent)
     : MatchTemplateResultsPanelParent(parent) {
@@ -27,6 +33,8 @@ MatchTemplateResultsPanel::MatchTemplateResultsPanel(wxWindow* parent)
     FillGroupComboBox( );
 
     Bind(wxEVT_CHAR_HOOK, &MatchTemplateResultsPanel::OnCharHook, this);
+    ResultDataView->my_parents_name        = "Match Template Results";
+    ResultDataView->OnHeaderClickInterrupt = &OnHeaderClick;
 }
 
 void MatchTemplateResultsPanel::OnCharHook(wxKeyEvent& event) {
@@ -347,8 +355,6 @@ void MatchTemplateResultsPanel::FillResultsPanelAndDetails(int row, int column) 
         IgnoreShiftedPeaksStaticText->SetLabel("No");
 
     RightPanel->Layout( );
-    ResultDataView->my_parents_name        = "MatchTemplate Results";
-    ResultDataView->OnHeaderClickInterrupt = &MatchTemplateResultsPanel::OnHeaderClick;
 }
 
 void MatchTemplateResultsPanel::OnValueChanged(wxDataViewEvent& event) {

--- a/src/gui/MatchTemplateResultsPanel.h
+++ b/src/gui/MatchTemplateResultsPanel.h
@@ -1,4 +1,3 @@
-extern MatchTemplatePanel* match_template_panel;
 
 class MatchTemplateResultsPanel : public MatchTemplateResultsPanelParent {
   public:
@@ -41,9 +40,4 @@ class MatchTemplateResultsPanel : public MatchTemplateResultsPanelParent {
     bool group_combo_is_dirty;
 
     wxString current_fill_command;
-
-    static void OnHeaderClick( ) {
-        // Rather than access members directly, create a method in MatchTemplatePanel to do this stuff.
-        match_template_panel->CheckForUnfinishedWork(true, false);
-    }
 };

--- a/src/gui/MyFindCTFResultsPanel.cpp
+++ b/src/gui/MyFindCTFResultsPanel.cpp
@@ -5,6 +5,8 @@ extern MyMainFrame*       main_frame;
 extern MyImageAssetPanel* image_asset_panel;
 extern MyMovieAssetPanel* movie_asset_panel;
 
+static inline void OnHeaderClick( ) { return; }
+
 MyFindCTFResultsPanel::MyFindCTFResultsPanel(wxWindow* parent)
     : FindCTFResultsPanel(parent) {
 
@@ -34,7 +36,7 @@ MyFindCTFResultsPanel::MyFindCTFResultsPanel(wxWindow* parent)
     Bind(wxEVT_CHAR_HOOK, &MyFindCTFResultsPanel::OnCharHook, this);
 
     ResultDataView->my_parents_name        = "CTF Results";
-    ResultDataView->OnHeaderClickInterrupt = &MyFindCTFResultsPanel::OnHeaderClick;
+    ResultDataView->OnHeaderClickInterrupt = &OnHeaderClick;
 }
 
 void MyFindCTFResultsPanel::OnPlotResultsButtonClick(wxCommandEvent& event) {

--- a/src/gui/MyFindCTFResultsPanel.h
+++ b/src/gui/MyFindCTFResultsPanel.h
@@ -58,6 +58,4 @@ class MyFindCTFResultsPanel : public FindCTFResultsPanel {
     bool group_combo_is_dirty;
 
     wxString current_fill_command;
-
-    static inline void OnHeaderClick( ) { return; }
 };

--- a/src/gui/MyMovieAlignResultsPanel.cpp
+++ b/src/gui/MyMovieAlignResultsPanel.cpp
@@ -4,6 +4,8 @@
 extern MyMovieAssetPanel* movie_asset_panel;
 extern MyImageAssetPanel* image_asset_panel;
 
+static inline void OnHeaderClick( ) { return; }
+
 MyMovieAlignResultsPanel::MyMovieAlignResultsPanel(wxWindow* parent)
     : MovieAlignResultsPanel(parent) {
 
@@ -30,7 +32,7 @@ MyMovieAlignResultsPanel::MyMovieAlignResultsPanel(wxWindow* parent)
     ResultPanel->SpectraPanel->use_auto_contrast = false;
 
     ResultDataView->my_parents_name        = "Movie Alignment Results";
-    ResultDataView->OnHeaderClickInterrupt = &MyMovieAlignResultsPanel::OnHeaderClick;
+    ResultDataView->OnHeaderClickInterrupt = &OnHeaderClick;
 }
 
 void MyMovieAlignResultsPanel::OnCharHook(wxKeyEvent& event) {

--- a/src/gui/MyMovieAlignResultsPanel.h
+++ b/src/gui/MyMovieAlignResultsPanel.h
@@ -43,5 +43,4 @@ class MyMovieAlignResultsPanel : public MovieAlignResultsPanel {
 
     wxString current_fill_command;
 
-    static inline void OnHeaderClick( ) { return; }
 };

--- a/src/gui/PickingResultsPanel.cpp
+++ b/src/gui/PickingResultsPanel.cpp
@@ -6,6 +6,8 @@ extern MyImageAssetPanel*            image_asset_panel;
 extern MyParticlePositionAssetPanel* particle_position_asset_panel;
 extern MyFindParticlesPanel*         findparticles_panel;
 
+static inline void OnHeaderClick( ) { return; }
+
 MyPickingResultsPanel::MyPickingResultsPanel(wxWindow* parent)
     : PickingResultsPanel(parent) {
 
@@ -29,7 +31,7 @@ MyPickingResultsPanel::MyPickingResultsPanel(wxWindow* parent)
 
     Bind(wxEVT_CHAR_HOOK, &MyPickingResultsPanel::OnCharHook, this);
     ResultDataView->my_parents_name        = "Picking Results";
-    ResultDataView->OnHeaderClickInterrupt = &MyPickingResultsPanel::OnHeaderClick;
+    ResultDataView->OnHeaderClickInterrupt = &OnHeaderClick;
 }
 
 MyPickingResultsPanel::~MyPickingResultsPanel( ) {

--- a/src/gui/PickingResultsPanel.h
+++ b/src/gui/PickingResultsPanel.h
@@ -43,6 +43,4 @@ class MyPickingResultsPanel : public PickingResultsPanel {
     bool group_combo_is_dirty;
 
     wxString current_fill_command;
-
-    static inline void OnHeaderClick( ) { return; }
 };


### PR DESCRIPTION
…nly be accessed withing a given panel

# Description

It turns out that static has multiple meanings depending on the scope it is used in:

If in a class scope (as previously in the results panel headers) the function could in principle be accessed without an instance of that class, eg.

```c++
non-static
MyResultsPanel.OnHeaderClick()
static
MyResultsPanel::OnHeaderClick()
```
Although unlikely to cause problems, a safer way is to instead but the declaration/defintion in the cpp, where then, a static function has internal linkage and can only be seen within that compilation unit.
```c++
#include myfile.h // may be include din many other places, which is why the previous approach could be bad

static inline OnHeaderClick(){};

MyFile::Myfile() {
    MyOtherFunctionPointer = &OnHeaderClick();
}
```




# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [X] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [X] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)