### PR TITLE
Make sure CI fails on error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,10 @@ jobs:
     - name: make 
       run: |
         cd build/${{ matrix.compiler }}
-        make | tee make.log
-        NUM_WARNING=$(cat make.log | grep warning | wc -l)
-        echo "::set-output name=numwarnings::$NUM_WARNING"
+        make 
+#        | tee make.log
+#        NUM_WARNING=$(cat make.log | grep warning | wc -l)
+#        echo "::set-output name=numwarnings::$NUM_WARNING"
         cp ../../scripts/testing/test_and_benchmark.sh src/
     - name: clean up
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     - name: make 
       run: |
         cd build/${{ matrix.compiler }}
-        make 
+        make -j2
         cp ../../scripts/testing/test_and_benchmark.sh src/
     - name: clean up
       run: |
@@ -95,7 +95,7 @@ jobs:
     - name: Fix permissions
       run: chmod +x *
     - name: test console_test
-      continue-on-error: true
+      continue-on-error: false
       run: ./console_test 
     - name: run benchmark
       run: ./test_and_benchmark.sh ./
@@ -122,7 +122,7 @@ jobs:
       if: ${{ matrix.compiler=='gcc' || matrix.compiler=='clang' }}
       run: sudo apt-get install -y libfftw3-dev 
     - name: test samples_functional_testing
-      continue-on-error: true
+      continue-on-error: false
       run: |
         chmod +x samples_functional_testing
         ./samples_functional_testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
       run: |
         cd build/${{ matrix.compiler }}
         make 
-#        | tee make.log
-#        NUM_WARNING=$(cat make.log | grep warning | wc -l)
-#        echo "::set-output name=numwarnings::$NUM_WARNING"
         cp ../../scripts/testing/test_and_benchmark.sh src/
     - name: clean up
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   build:
-    continue-on-error: true
+    continue-on-error: false
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         compiler: [icpc,gcc,clang]
         include:
@@ -80,7 +80,7 @@ jobs:
 
   console_test:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         compiler: [icpc,gcc,clang]
     name: Console test
@@ -109,7 +109,7 @@ jobs:
 
   samples_functional_testing:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         compiler: [icpc,gcc,clang]
     name: Samples functional testing

--- a/src/gui/MatchTemplatePanel.cpp
+++ b/src/gui/MatchTemplatePanel.cpp
@@ -1156,7 +1156,7 @@ void MatchTemplatePanel::CheckForUnfinishedWork(bool is_checked, bool is_from_ch
         int         images_successfully_processed = 0;
         wxArrayLong unfinished_match_template_ids;
 
-        if ( selected_image_group == -1 ) {
+        if ( active_group.id == -1 ) {
             unfinished_match_template_ids = main_frame->current_project.database.ReturnLongArrayFromSelectCommand(
                     wxString::Format("select IMAGE_ASSETS.IMAGE_ASSET_ID, COMP.IMAGE_ASSET_ID as CID FROM IMAGE_ASSETS "
                                      "LEFT JOIN (SELECT IMAGE_ASSET_ID FROM TEMPLATE_MATCH_LIST WHERE TEMPLATE_MATCH_JOB_ID = %i ) COMP "

--- a/src/programs/console_test/console_test.cpp
+++ b/src/programs/console_test/console_test.cpp
@@ -462,8 +462,6 @@ void MyTestApp::TestDatabase( ) {
 
     wxString database_filename = temp_directory + "/1_0_test/1_0_test.db";
     Project  project;
-    project.OpenProjectFromFile(database_filename);
-    project.Close(false, false);
     Database database;
     database.Open(database_filename);
     auto schema_result = database.CheckSchema( );

--- a/src/programs/console_test/console_test.cpp
+++ b/src/programs/console_test/console_test.cpp
@@ -459,7 +459,8 @@ void MyTestApp::TestDatabase( ) {
     BeginTest("Database");
 
     temp_directory = wxFileName::GetTempDir( );
-
+    // temporary test
+    FailTest;
     wxString database_filename = temp_directory + "/1_0_test/1_0_test.db";
     Project  project;
     Database database;
@@ -1796,6 +1797,7 @@ void MyTestApp::PrintResultWorker(bool passed, int line) {
             wxPrintf(ANSI_COLOR_RED "FAILED! (Line : %i)" ANSI_COLOR_RESET, line);
         else
             wxPrintf("FAILED! (Line : %i)", line);
+        exit(1);
     }
 
     wxPrintf("\n");

--- a/src/programs/console_test/console_test.cpp
+++ b/src/programs/console_test/console_test.cpp
@@ -459,8 +459,6 @@ void MyTestApp::TestDatabase( ) {
     BeginTest("Database");
 
     temp_directory = wxFileName::GetTempDir( );
-    // temporary test
-    FailTest;
     wxString database_filename = temp_directory + "/1_0_test/1_0_test.db";
     Project  project;
     Database database;

--- a/src/programs/samples/common/helper_functions.cpp
+++ b/src/programs/samples/common/helper_functions.cpp
@@ -157,6 +157,7 @@ void SamplesPrintResult(bool passed, int line) {
             wxPrintf(ANSI_COLOR_RED "FAILED! (Line : %i)" ANSI_COLOR_RESET, line);
         else
             wxPrintf("FAILED! (Line : %i)", line);
+        exit(1);
     }
 
     wxPrintf("\n");


### PR DESCRIPTION
# Description
This small change should make sure that the CI shows an error if the compilation fails and should fail faster.

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
