### PR TITLE
Make match template jobs resumable in the GUI

### DIFF
--- a/src/core/database.cpp
+++ b/src/core/database.cpp
@@ -1751,6 +1751,10 @@ void Database::AddTemplateMatchingResult(long wanted_template_match_id, Template
     EndBatchInsert( );
 }
 
+/** 
+ * Returns the Template Match ID for one result of a given Job
+*/
+
 long Database::GetTemplateMatchIdForGivenJobId(long wanted_template_match_job_id) {
     wxString sql_select_command = wxString::Format("SELECT TEMPLATE_MATCH_ID FROM TEMPLATE_MATCH_LIST WHERE TEMPLATE_MATCH_JOB_ID=%li", wanted_template_match_job_id);
     return ReturnSingleLongFromSelectCommand(sql_select_command);

--- a/src/core/database.cpp
+++ b/src/core/database.cpp
@@ -1751,6 +1751,11 @@ void Database::AddTemplateMatchingResult(long wanted_template_match_id, Template
     EndBatchInsert( );
 }
 
+long Database::GetTemplateMatchIdForGivenJobId(long wanted_template_match_job_id) {
+    wxString sql_select_command = wxString::Format("SELECT TEMPLATE_MATCH_ID FROM TEMPLATE_MATCH_LIST WHERE TEMPLATE_MATCH_JOB_ID=%li", wanted_template_match_job_id);
+    return ReturnSingleLongFromSelectCommand(sql_select_command);
+}
+
 TemplateMatchJobResults Database::GetTemplateMatchingResultByID(long wanted_template_match_id) {
     TemplateMatchJobResults    temp_result;
     TemplateMatchFoundPeakInfo temp_peak_info;

--- a/src/core/database.h
+++ b/src/core/database.h
@@ -341,6 +341,7 @@ class Database {
     void AddTemplateMatchingResult(long wanted_template_match_id, TemplateMatchJobResults& job_details);
 
     TemplateMatchJobResults GetTemplateMatchingResultByID(long wanted_template_match_id);
+    long GetTemplateMatchIdForGivenJobId(long wanted_template_match_job_id);
 
     void AddRefinementAngularDistribution(AngularDistributionHistogram& histogram_to_add, long refinement_id, int class_number);
     void CopyRefinementAngularDistributions(long refinement_id_to_copy, long refinement_id_to_copy_to, int wanted_class_number);

--- a/src/gui/MatchTemplatePanel.cpp
+++ b/src/gui/MatchTemplatePanel.cpp
@@ -507,11 +507,12 @@ void MatchTemplatePanel::SetInputsForPossibleReRun(bool set_up_to_resume_job, Te
     SetAndRememberEnableState(DefocusSearchStepNumericCtrl, was_enabled_DefocusSearchStepNumericCtrl, enable_value);
 
     // We still want things that are needed to re-run the job to be enabled.
-#ifdef ENABLEGPU
-    UseGpuCheckBox->SetValue(true);
-#else
-    UseGpuCheckBox->SetValue(false); // Already disabled, but also set to un-ticked for visual consistency.
-#endif
+    // This might not be needed
+    //#ifdef ENABLEGPU
+    //    UseGpuCheckBox->SetValue(true);
+    //#else
+    //    UseGpuCheckBox->SetValue(false); // Already disabled, but also set to un-ticked for visual consistency.
+    //#endif
 
     // It is okay to change the run profile for a rerun
     if ( RunProfileComboBox->GetCount( ) > 0 ) {
@@ -1183,6 +1184,9 @@ wxArrayLong MatchTemplatePanel::CheckForUnfinishedWork(bool is_checked, bool is_
     // When the header in the results panel is changed.
     wxArrayLong unfinished_match_template_ids;
     if ( is_checked ) {
+        // active group might have been overriden when resuming a run
+        active_group.CopyFrom(&image_asset_panel->all_groups_list->groups[GroupComboBox->GetSelection( )]);
+
         int active_job_id = match_template_results_panel->ResultDataView->ReturnActiveJobID( );
         // Dummy values that should be set by the above method to query the DB
         int images_total                  = active_group.number_of_members;
@@ -1219,6 +1223,7 @@ wxArrayLong MatchTemplatePanel::CheckForUnfinishedWork(bool is_checked, bool is_
                 check_dialog->ShowModal( );
             }
             ResumeRunCheckBox->SetValue(false);
+            SetInputsForPossibleReRun(false);
         }
         else {
             wxPrintf("Checking for unfinished work for job %d\n", active_job_id);

--- a/src/gui/MatchTemplatePanel.h
+++ b/src/gui/MatchTemplatePanel.h
@@ -40,22 +40,6 @@ class MatchTemplatePanel : public MatchTemplatePanelParent {
     bool was_enabled_DefocusSearchRangeNumericCtrl;
     bool was_enabled_DefocusSearchStepNumericCtrl;
 
-    // Save the currently set values of the controls.
-    // These are *not* set until a call to SetInputsForPossibleReRun(true)
-    bool     was_values_set = false;
-    long     was_value_ReferenceSelectPanel;
-    float    was_value_OutofPlaneStepNumericCtrl;
-    float    was_value_InPlaneStepNumericCtrl;
-    float    was_value_MinPeakRadiusNumericCtrl;
-    bool     was_value_DefocusSearchYesRadio;
-    bool     was_value_DefocusSearchNoRadio;
-    bool     was_value_PixelSizeSearchYesRadio;
-    bool     was_value_PixelSizeSearchNoRadio;
-    wxString was_value_SymmetryComboBox;
-    float    was_value_HighResolutionLimitNumericCtrl;
-    float    was_value_DefocusSearchRangeNumericCtrl;
-    float    was_value_DefocusSearchStepNumericCtrl;
-
   public:
     MatchTemplatePanel(wxWindow* parent);
 

--- a/src/gui/MatchTemplatePanel.h
+++ b/src/gui/MatchTemplatePanel.h
@@ -40,6 +40,22 @@ class MatchTemplatePanel : public MatchTemplatePanelParent {
     bool was_enabled_DefocusSearchRangeNumericCtrl;
     bool was_enabled_DefocusSearchStepNumericCtrl;
 
+    // Save the currently set values of the controls.
+    // These are *not* set until a call to SetInputsForPossibleReRun(true)
+    bool     was_values_set = false;
+    long     was_value_ReferenceSelectPanel;
+    float    was_value_OutofPlaneStepNumericCtrl;
+    float    was_value_InPlaneStepNumericCtrl;
+    float    was_value_MinPeakRadiusNumericCtrl;
+    bool     was_value_DefocusSearchYesRadio;
+    bool     was_value_DefocusSearchNoRadio;
+    bool     was_value_PixelSizeSearchYesRadio;
+    bool     was_value_PixelSizeSearchNoRadio;
+    wxString was_value_SymmetryComboBox;
+    float    was_value_HighResolutionLimitNumericCtrl;
+    float    was_value_DefocusSearchRangeNumericCtrl;
+    float    was_value_DefocusSearchStepNumericCtrl;
+
   public:
     MatchTemplatePanel(wxWindow* parent);
 
@@ -95,7 +111,7 @@ class MatchTemplatePanel : public MatchTemplatePanelParent {
     void ResetDefaults( );
 
     // Functions for interacting with the results panel and possibly resuming a job
-    void SetInputsForPossibleReRun(bool set_up_to_resume_job);
+    void SetInputsForPossibleReRun(bool set_up_to_resume_job, TemplateMatchJobResults* results_to_resume = nullptr);
 
     template <class T>
     inline void SetAndRememberEnableState(T* control_to_disable, bool& was_enabled, bool set_to = false) {
@@ -103,8 +119,8 @@ class MatchTemplatePanel : public MatchTemplatePanelParent {
         control_to_disable->Enable(set_to);
     }
 
-    void ResumeRunCheckBoxOnCheckBox(wxCommandEvent& event);
-    void CheckForUnfinishedWork(bool is_checked, bool is_from_check_box);
+    void        ResumeRunCheckBoxOnCheckBox(wxCommandEvent& event);
+    wxArrayLong CheckForUnfinishedWork(bool is_checked, bool is_from_check_box);
 };
 
 #endif


### PR DESCRIPTION
# Description

Building on #393 and #379 this enables resuming of match_template jobs. Furthermore it also allows to add images to an already existing matching job. For example one could run matching first on a few images and if the results look good resume matching on all images, within the same job. No changes to the database were required.


https://user-images.githubusercontent.com/6081039/161850020-c01177a8-9ee7-4ed0-ae5f-ed8ec117a835.mp4


The code is still somewhat unclean, hopefully we can have some discussion here.

Fixes #390

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- x ] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
