### PR TITLE
Enable CMake build on MacOS. Tested with ctffind

### DIFF
--- a/.vscode_shared/AlexisRohou/c_cpp_properties.json
+++ b/.vscode_shared/AlexisRohou/c_cpp_properties.json
@@ -5,8 +5,8 @@
             "includePath": [
                 "${workspaceFolder}/**",
                 "/usr/local/include",
-                "/usr/local/lib/wx/include/osx_cocoa-unicode-3.0",
-                "/usr/local/include/wx-3.0"
+                "/usr/local/lib/wx/include/osx_cocoa-unicode-3.2",
+                "/usr/local/include/wx-3.2"
             ],
             "defines": [
                 "_FILE_OFFSET_BITS=64",

--- a/.vscode_shared/AlexisRohou/settings.json
+++ b/.vscode_shared/AlexisRohou/settings.json
@@ -8,7 +8,7 @@
     "cmake.configureSettings": {
         "BUILD_EXPERIMENTAL_FEATURES":true,
         "BUILD_STATIC_BINARIES":false,
-        "BUILD_OpenMP":true,
+        "USE_OpenMP":true,
     },
     //"cmake.configureEnvironment": {
     //    "WX_CONFIG":"/path/to/your/wx/bin/wx-config",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # or from settings.json in vscode, set same variables
 #
 project(cisTEM)
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.12)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake_modules" ${CMAKE_MODULE_PATH})
 
 # specify the C++ standard
@@ -30,18 +30,38 @@ else()
 
 endif(BUILD_EXPERIMENTAL_FEATURES)
 
-# OpenMP build option
-option(BUILD_OpenMP "Enable OpenMP for multithreading" OFF)
-if (BUILD_OpenMP)
-    find_package(OpenMP)
-    if(OpenMP_FOUND OR OpenMP_CXX_FOUND)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-    else()
-        message(FATAL_ERROR "Build step for OpenMP failed.")
+# OpenMP 
+OPTION (USE_OpenMP "Use OpenMP" ON)
+if (USE_OpenMP)
+    if(APPLE)
+        if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+            set(OpenMP_C "${CMAKE_C_COMPILER}")
+            set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -Wno-unused-command-line-argument")
+            set(OpenMP_C_LIB_NAMES "libomp" "libgomp" "libiomp5")
+            set(OpenMP_libomp_LIBRARY ${OpenMP_C_LIB_NAMES})
+            set(OpenMP_libgomp_LIBRARY ${OpenMP_C_LIB_NAMES})
+            set(OpenMP_libiomp5_LIBRARY ${OpenMP_C_LIB_NAMES})
+        endif()
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            set(OpenMP_CXX "${CMAKE_CXX_COMPILER}")
+            set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -Wno-unused-command-line-argument")
+            set(OpenMP_CXX_LIB_NAMES "libomp" "libgomp" "libiomp5")
+            set(OpenMP_libomp_LIBRARY ${OpenMP_CXX_LIB_NAMES})
+            set(OpenMP_libgomp_LIBRARY ${OpenMP_CXX_LIB_NAMES})
+            set(OpenMP_libiomp5_LIBRARY ${OpenMP_CXX_LIB_NAMES})
+        endif()
     endif()
-endif(BUILD_OpenMP)
+    find_package(OpenMP)
+    if (OpenMP_FOUND)
+        message("OpenMP was found")
+    endif(OpenMP_FOUND)
+    if (OpenMP_CXX_FOUND)
+        message("OpenMP_CXX was found")
+        include_directories(${OpenMP_INCLUDE_DIRS})
+    endif()
+endif(USE_OpenMP)
+
+
 
 #
 # Let's link in static libraries
@@ -99,6 +119,14 @@ else()
     #
     find_package(FFTW REQUIRED COMPONENTS FLOAT_LIB)
     include_directories(${FFTW_INCLUDE_DIRS})
+    message("FFTW libraries = ${FFTW_LIBRARIES}")
+
+    #
+    # MacOS: Seems that the homebrew FFTW expects OpenMPI at runtime, so let's hope we can find it
+    # Shame findFFTW does not do this for us :(
+    #
+    find_package(MPI)
+    message("MPI libraries = ${MPI_LIBRARIES}")
 endif()
 
 
@@ -173,6 +201,17 @@ if(Git_FOUND)
         string(REGEX REPLACE "\n$" "" GIT_COMMIT "${GIT_COMMIT}")
         message("Current Git commit is ${GIT_COMMIT}")
         add_definitions(" -DCISTEM_GIT_COMMIT=\"\\\"${GIT_COMMIT}\\\"\" " )
+
+        execute_process(    COMMAND bash "-c" "${GIT_EXECUTABLE} branch | awk '/^\\*/{print $2}'"
+                            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                            OUTPUT_VARIABLE CISTEM_CURRENT_BRANCH )
+        message("Current branch is ${CISTEM_CURRENT_BRANCH}" )
+        add_definitions(" -DCISTEM_CURRENT_BRANCH=\"\\\"${CISTEM_CURRENT_BRANCH}\\\"\" " )
+        execute_process(    COMMAND bash "-c" "${GIT_EXECUTABLE} rev-list ${version_commit}..HEAD | awk -v NAME=$version_name -v ISDIRTY=$is_dirty 'BEGIN{n=0}{n=n+1}{if(FNR==1) H=$1}END{print NAME\"-\"n-1\"-\"substr(H,1,7)ISDIRTY}'"
+                            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"                    
+                            OUTPUT_VARIABLE CISTEM_VERSION_TEXT)
+        message("Version text is ${CISTEM_VERSION_TEXT}" )
+        add_definitions(" -DCISTEM_VERSION_TEXT=\"\\\"${CISTEM_VERSION_TEXT}\\\"\" " )
     endif()
 endif()
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -71,8 +71,13 @@ endif(BUILD_EXPERIMENTAL_FEATURES)
 
 target_link_libraries(cisTEM_core ${CMAKE_DL_LIBS})
 target_link_libraries(cisTEM_core ${FFTW_LIBRARIES})
+target_link_libraries(cisTEM_core ${MPI_LIBRARIES})
 target_link_libraries(cisTEM_core ${wxWidgets_LIBRARIES})
 target_link_libraries(cisTEM_core ${TIFF_LIBRARIES})
+
+if (USE_OpenMP)
+	target_link_libraries(cisTEM_core ${OpenMP_LIBRARIES})
+endif(USE_OpenMP)
 
 target_link_libraries(cisTEM_gui_core ${wxWidgets_LIBRARIES})
 

--- a/src/core/cistem_parameters.cpp
+++ b/src/core/cistem_parameters.cpp
@@ -2090,7 +2090,7 @@ int cisTEMParameters::ReturnMaxPositionInStack(bool exclude_negative_film_number
 
 static int wxCMPFUNC_CONV SortByReference3DFilenameCompareFunction(cisTEMParameterLine** a, cisTEMParameterLine** b) // function for sorting the classum selections by parent_image_id - this makes cutting them out more efficient
 {
-    return wxStringSortAscending(&(*a)->reference_3d_filename, &(*b)->reference_3d_filename);
+    return wxStringSortAscending((*a)->reference_3d_filename, (*b)->reference_3d_filename);
 };
 
 void cisTEMParameters::SortByReference3DFilename( ) {

--- a/src/core/core_headers.h
+++ b/src/core/core_headers.h
@@ -22,7 +22,9 @@ typedef struct CurvePoint {
 } CurvePoint;
 
 // All the defines set in configure.ac
+#ifdef ENABLEGPU
 #include <cistem_config.h>
+#endif
 #ifndef _LARGE_FILE_SOURCE
 #define _LARGE_FILE_SOURCE
 #endif


### PR DESCRIPTION
# Description

The latest from repo did not build with CMake on MacOS. This fixes this problem. I have confirmed that ctffind builds on MacOS 10.15.7 using Clang and FFTW + OpenMP + OpenMPI from homebrew. I have also verified that ctffind runs to completion on test data.

In the process, I believe I fixed a bug in cistem_parameters.cpp (or at least clang thinks I did). BUT: I have not tested this functionality - I don't know where it is used. I would appreciate if someone who uses this functionality could build & test before we merge. Perhaps @bHimes or @timothygrant80 knows where this is used and can see whether I fixed or broke something.

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ x] other (clang 12)

# These changes are isolated to the

- [ ] gui
- [x ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

I can build ctffind on MacOS using CMake and clang.

Warning: I have not tested building using autotools on MacOS, or at all on linux.
Warning 2: it's likely that the GPU-enabled side of things will not build with CMake, but I believe this was already the case before these commits (I guess cmake builds just were not tested)

- [ ] Tested manually from GUI
- [ x] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
