### PR TITLE
Template matching to single particle gui crash fix

### DIFF
--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -915,7 +915,7 @@ void MyMainFrame::SetSingleParticleWorkflow(bool triggered_by_gui_event) {
             }
         }
         current_workflow = cistem::workflow::single_particle;
-        current_project.RecordCurrentWorkflowInDB(current_workflow);
+        if (current_project.is_open == true) current_project.RecordCurrentWorkflowInDB(current_workflow);
         // If not called from the GUI, we need to update the menu.
         if ( ! triggered_by_gui_event ) {
             ManuallyUpdateWorkflowMenuCheckBox( );
@@ -932,7 +932,7 @@ void MyMainFrame::SetTemplateMatchingWorkflow(bool triggered_by_gui_event) {
         previous_workflow = current_workflow;
         UpdateWorkflow(actions_panel_spa, actions_panel_tm, "Actions");
         current_workflow = cistem::workflow::template_matching;
-        current_project.RecordCurrentWorkflowInDB(current_workflow);
+        if (current_project.is_open == true) current_project.RecordCurrentWorkflowInDB(current_workflow);
 
         // If not called from the GUI, we need to update the menu.
         if ( ! triggered_by_gui_event ) {


### PR DESCRIPTION
# Description

Simply added a check with gui/MainFrame.cpp to only attempt a database update if a database is actually open. Previously, this would cause a crash.


# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ x] yes
- [ ] no

# Which compilers were tested

- [ x] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ x] I have not changed anything that did not need to be changed
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
