### PR TITLE
Odd crash fix

### DIFF
--- a/src/gui/my_controls.cpp
+++ b/src/gui/my_controls.cpp
@@ -1003,7 +1003,7 @@ wxString RefinementPackageListControl::OnGetItemText(long item, long column) con
 
     MyRefinementPackageAssetPanel* parent_panel = reinterpret_cast<MyRefinementPackageAssetPanel*>(m_parent->GetParent( )->GetParent( )); // not very nice code!
 
-    if ( parent_panel->all_refinement_packages.GetCount( ) > 0 ) {
+    if ( parent_panel->all_refinement_packages.GetCount( ) > 0 && item < parent_panel->all_refinement_packages.GetCount()) {
         return parent_panel->all_refinement_packages.Item(item).name;
     }
     else

--- a/src/gui/my_controls.cpp
+++ b/src/gui/my_controls.cpp
@@ -1003,7 +1003,7 @@ wxString RefinementPackageListControl::OnGetItemText(long item, long column) con
 
     MyRefinementPackageAssetPanel* parent_panel = reinterpret_cast<MyRefinementPackageAssetPanel*>(m_parent->GetParent( )->GetParent( )); // not very nice code!
 
-    if ( parent_panel->all_refinement_packages.GetCount( ) > 0 && item < parent_panel->all_refinement_packages.GetCount()) {
+    if ( parent_panel->all_refinement_packages.GetCount( ) > 0 && item < parent_panel->all_refinement_packages.GetCount( ) ) {
         return parent_panel->all_refinement_packages.Item(item).name;
     }
     else


### PR DESCRIPTION
When closing a project and switching to a project with fewer refinement packages than the first another while the refinement package asset panel was open led to a crash. Now, check that the item (package index) is smaller than the count of refinement_packages in the database.



# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [x] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
