### PR TITLE
fixes eer directory import

### DIFF
--- a/src/gui/MovieImportDialog.h
+++ b/src/gui/MovieImportDialog.h
@@ -1,5 +1,5 @@
-#ifndef __MyMovieImportDialog__
-#define __MyMovieImportDialog__
+#ifndef __SRC_GUI__MyMovieImportDialog__
+#define __SRC_GUI__MyMovieImportDialog__
 
 /**
 @file
@@ -23,12 +23,15 @@ class MyMovieImportDialog : public MovieImportDialog {
     void OnTextKeyPress(wxKeyEvent& event);
     void CheckImportButtonStatus( );
     void TextChanged(wxCommandEvent& event);
+    void CheckForEERFiles(wxArrayString& filenames, wxString& current_extension, bool& at_least_one_eer_file);
 
     void OnMoviesAreGainCorrectedCheckBox(wxCommandEvent& event);
     void OnCorrectMagDistortionCheckBox(wxCommandEvent& event);
     void OnGainFilePickerChanged(wxFileDirPickerEvent& event);
     void OnResampleMoviesCheckBox(wxCommandEvent& event);
     void OnSkipFullIntegrityCheckCheckBox(wxCommandEvent& event);
+
+    const char* Type( ) const { return "ImportMovieDialog"; };
 };
 
 #endif // __MyMovieImportDialog__


### PR DESCRIPTION
# Description

When importing eer files as a directory, there is currently no check that an eer_file exists, so the eer options (like sampling) are not enabled in the wizard.

This adds a new method to check, that is now called both for directory or file based import.

I also added extensions that were missing in the director import (and left a note suggesting a more robust TODO item to avoid inconsistent features in the future.

**NOTE:**
This is a manual diff from my private repo and may require some touching up, but I *think* everything is there. Consider them really good notes ; )

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [X] other (the thoughts and prayers compiler)

# These changes are isolated to the

- [X] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [X] other (NONE)

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ? ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
