### PR TITLE
Correct B-Factor handling in simulator

### DIFF
--- a/src/programs/simulate/simulate.cpp
+++ b/src/programs/simulate/simulate.cpp
@@ -525,7 +525,7 @@ class SimulateApp : public MyApp {
     void apply_sqrt_DQE_or_NTF(Image* image_in, int iTilt_IDX, bool do_root_DQE);
 
     inline float return_bfactor(float pdb_bfactor) {
-        return 0.25f * (this->min_bFactor + pdb_bfactor * this->bFactor_scaling);
+        return (this->min_bFactor + pdb_bfactor * this->bFactor_scaling);
     }
 
     inline float return_scattering_potential(corners& R, float* bPlusB, AtomType& atom_id) {


### PR DESCRIPTION
# Description

We have been noticing that 3D maps generated from the simulator look noticeably less blurry at a given B-factor than maps that have been filtered with the bfactor program. Comparing the code with eq (12) in Himes, IUCrJ 2021 it seems like 0.25 is multiplied with the B-factor that should not apply in this case. After removing it the blurriness of the resulting maps seems fixed.

@bHimes does this seem right to you? 

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [x] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [x] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
