### PR TITLE
Add Image::CalculateBfactor

### DIFF
--- a/src/core/curve.cpp
+++ b/src/core/curve.cpp
@@ -416,6 +416,20 @@ void Curve::Logarithm( ) {
     }
 }
 
+// Replace Y values with their natural logarthm base e
+void Curve::Ln( ) {
+#ifdef CISTEM_DEBUG
+    for ( int counter = 0; counter < number_of_points; counter++ ) {
+        if ( data_y[counter] < 0.0 )
+            MyDebugAssertTrue(false, "This routine assumes all Y values are positive, but value %i is %f\n", counter, data_y[counter]);
+    }
+#endif
+
+    for ( int counter = 0; counter < number_of_points; counter++ ) {
+        data_y[counter] = std::log(data_y[counter]);
+    }
+}
+
 void Curve::SquareRoot( ) {
 #ifdef DEBUG
     for ( int counter = 0; counter < number_of_points; counter++ ) {

--- a/src/core/curve.h
+++ b/src/core/curve.h
@@ -68,6 +68,7 @@ class Curve {
     float      ReturnFullWidthAtGivenValue(const float& wanted_value);
     void       NormalizeMaximumValue( );
     void       Logarithm( );
+    void       Ln( );
     void       ZeroYData( );
     void       ApplyCTF(CTF ctf_to_apply, float azimuth_in_radians = 0.0);
     void       SquareRoot( );

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -287,6 +287,10 @@ class Image {
         return (logical_x_dimension == logical_y_dimension);
     }
 
+    inline bool IsSquareOrCubic( ) {
+        return (logical_x_dimension == logical_y_dimension && (logical_z_dimension > 1) ? (logical_y_dimension == logical_z_dimension) : true);
+    }
+
     inline void ReturnCosineMaskBandpassResolution(float pixel_size_in_angstrom, float& wanted_cutoff_in_angstrom, float& wanted_falloff_in_number_of_fourier_space_voxels) {
         // For example, if you want a cutoff at 2 Angstrom res, with a 14 pixel fall off, and your image is at 1.2 apix, inputs will be 1.2, 2, 14
         // output in the last two args will be the mask_outer_radius, and mask_edge that are passed to CosineRingMask.
@@ -406,6 +410,7 @@ class Image {
     void  AddImage(Image* other_image);
     void  SubtractImage(Image* other_image);
     void  SubtractSquaredImage(Image* other_image);
+    float CalculateBFactor(float pixel_size, float low_resolution = 10.f, float high_resolution = 4.0f);
     void  ApplyBFactor(float bfactor);
     void  ApplyBFactorAndWhiten(Curve& power_spectrum, float bfactor_low, float bfactor_high, float bfactor_res_limit);
     void  CalculateDerivative(float direction_in_x = 0.0f, float direction_in_y = 0.0f, float direction_in_z = 0.0f);


### PR DESCRIPTION
# Description

Adds an image method to return a fit of ln(avg fourier amplitudes) vs (1/Ang^2)

Fixes # (issue)

Related to pr #415. Used to evaluate 3ds from bfactor and simulator for expected slope. 

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [X] other (none)

# These changes are isolated to the

- [ ] gui
- [X] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [X] Tested manually from CLI (in my repo, this is an untested manual patch)
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings (in my repo)
- [ ] Any dependent changes have been merged and published in downstream modules
