### PR TITLE
Fix cisTEM not loading images with certain sizes

### DIFF
--- a/src/core/functions.cpp
+++ b/src/core/functions.cpp
@@ -111,7 +111,7 @@ bool GetMRCDetails(const char* filename, int& x_size, int& y_size, int& number_o
             return false;
         }
 
-        bytes_per_slice = long(float(number_of_pixels) * bytes_per_pixel + 0.5f + pad_bytes);
+        bytes_per_slice = long(double(number_of_pixels) * bytes_per_pixel + 0.5f + pad_bytes);
 
         // now we need to know the number of bytes in the extended header...
 


### PR DESCRIPTION
# Description


Ok, this is a fun one! For a while I had the problem that cisTEM rejects some images, claiming they are not valid. Turns out this happens only for certain sizes, such as 4143x4245 with floating points. 

As it turns out, the problem is that in the `GetMRCDetails` method the size of the file is checked against the expected number of bytes. When the expected number of bytes is calculated it is temporarily converted into a float

```
bytes_per_slice = long(float(number_of_pixels) * bytes_per_pixel + 0.5f + pad_bytes);
```

However, the number of bytes has typically 8 digits, while floats are only accurate for about 7 digits. You can clearly see this from this short program:

```
#include <iostream>

using namespace std;

int main()
{
    cout<<long(float(70348140)); // 4143 * 4245 * 4
    return 0;
}
```
which outputs
```
70348144
```

I have fixed this for now by using a double instead of a float for the calculation, but I question why floating points are used when the number of bytes always will be an integer. This might be connected with the addition of `0.5f`, which I don't understand. Maybe @timothygrant80 or @arohou know what the original thinking was?

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
