### PR TITLE
[Feature] Thickness attribute in ctf class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -243,7 +243,7 @@ endif
 
 noinst_LIBRARIES = libcore.a libguicore.a
 
-bin_PROGRAMS = unblur cisTEM_job_control console_test applyctf reconstruct3d merge3d project3d refine3d calc_occ ctffind remove_outlier_pixels resize resample reset_mrc_header estimate_dataset_ssnr find_particles montage extract_particles sum_all_mrc_files sum_all_tif_files apply_gain_ref scale_with_mask refine2d merge2d mag_distortion_correct apply_mask convert_tif_to_mrc remove_inf_and_nan make_orth_views sharpen_map calculate_fsc make_size_map prepare_stack prepare_stack_classaverage align_symmetry subtract_from_stack binarize  move_volume_xyz  symmetry_expand_stack_and_par fft local_resolution local_resolution_finalize local_resolution_filter subtract_two_stacks add_two_stacks multiply_two_stacks divide_two_stacks invert_stack convert_par_to_star align_coordinates find_dqe combine_via_max refine_ctf estimate_beamtilt remove_relion_stripes warp_to_cistem create_mask invert_hand niko_test append_stacks cisTEM convert_star_to_binary convert_binary_to_star convert_eer_to_mrc azimuthal_average normalize_stack print_stack_statistics combine_stacks_by_star match_template refine_template make_template_result prepare_stack_matchtemplate
+bin_PROGRAMS = unblur cisTEM_job_control console_test applyctf reconstruct3d merge3d project3d refine3d calc_occ ctffind remove_outlier_pixels resize resample reset_mrc_header estimate_dataset_ssnr find_particles montage extract_particles sum_all_mrc_files sum_all_tif_files apply_gain_ref scale_with_mask refine2d merge2d mag_distortion_correct apply_mask convert_tif_to_mrc remove_inf_and_nan make_orth_views sharpen_map calculate_fsc make_size_map prepare_stack prepare_stack_classaverage align_symmetry subtract_from_stack binarize  move_volume_xyz  symmetry_expand_stack_and_par fft local_resolution local_resolution_finalize local_resolution_filter subtract_two_stacks add_two_stacks multiply_two_stacks divide_two_stacks invert_stack convert_par_to_star align_coordinates find_dqe combine_via_max refine_ctf estimate_beamtilt remove_relion_stripes warp_to_cistem create_mask invert_hand niko_test append_stacks cisTEM gui_test convert_star_to_binary convert_binary_to_star convert_eer_to_mrc azimuthal_average normalize_stack print_stack_statistics combine_stacks_by_star match_template refine_template make_template_result prepare_stack_matchtemplate
 
 if EXPERIMENTAL_AM   
 bin_PROGRAMS += refine_template_dev simulate sum_all_power_spectra
@@ -361,6 +361,12 @@ cisTEM_CXXFLAGS = $(WX_CPPFLAGS)
 cisTEM_CPPFLAGS = $(WX_CPPFLAGS)
 cisTEM_LDADD = libguicore.a libcore.a $(WX_LIBS)
 
+gui_test_SOURCES = programs/gui_test/gui_test.cpp gui/PlotCurvePanel.cpp gui/mathplot.cpp
+
+gui_test_CXXFLAGS = $(WX_CPPFLAGS)
+gui_test_CPPFLAGS = $(WX_CPPFLAGS)
+gui_test_LDADD = libguicore.a libcore.a $(WX_LIBS)
+
 cisTEM_job_control_SOURCES = programs/guix_job_control/guix_job_control.cpp 
 cisTEM_job_control_CXXFLAGS = $(WX_CPPFLAGS_BASE)
 cisTEM_job_control_CPPFLAGS = $(WX_CPPFLAGS_BASE)
@@ -385,6 +391,11 @@ ctffind_SOURCES = programs/ctffind/ctffind.cpp
 ctffind_CXXFLAGS = $(WX_CPPFLAGS_BASE)
 ctffind_CPPFLAGS = $(WX_CPPFLAGS_BASE)
 ctffind_LDADD = libcore.a $(WX_LIBS_BASE)
+
+ctfplot_SOURCES = programs/ctffind/ctfplot.cpp
+ctfplot_CXXFLAGS = $(WX_CPPFLAGS_BASE)
+ctfplot_CPPFLAGS = $(WX_CPPFLAGS_BASE)
+ctfplot_LDADD = libcore.a $(WX_LIBS_BASE)
 
 reconstruct3d_SOURCES = programs/reconstruct3d/reconstruct3d.cpp
 reconstruct3d_CXXFLAGS = $(WX_CPPFLAGS_BASE)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -392,11 +392,6 @@ ctffind_CXXFLAGS = $(WX_CPPFLAGS_BASE)
 ctffind_CPPFLAGS = $(WX_CPPFLAGS_BASE)
 ctffind_LDADD = libcore.a $(WX_LIBS_BASE)
 
-ctfplot_SOURCES = programs/ctffind/ctfplot.cpp
-ctfplot_CXXFLAGS = $(WX_CPPFLAGS_BASE)
-ctfplot_CPPFLAGS = $(WX_CPPFLAGS_BASE)
-ctfplot_LDADD = libcore.a $(WX_LIBS_BASE)
-
 reconstruct3d_SOURCES = programs/reconstruct3d/reconstruct3d.cpp
 reconstruct3d_CXXFLAGS = $(WX_CPPFLAGS_BASE)
 reconstruct3d_CPPFLAGS = $(WX_CPPFLAGS_BASE)

--- a/src/core/ctf.cpp
+++ b/src/core/ctf.cpp
@@ -16,6 +16,7 @@ CTF::CTF( ) {
     particle_shift_x       = 0;
     particle_shift_y       = 0;
     particle_shift         = 0;
+    sample_thickness       = 0;
     particle_shift_azimuth = 0;
     // Fitting parameters
     lowest_frequency_for_fitting    = 0;
@@ -46,9 +47,10 @@ CTF::CTF(float wanted_acceleration_voltage, // keV
          float wanted_beam_tilt_x_in_radians, // rad
          float wanted_beam_tilt_y_in_radians, // rad
          float wanted_particle_shift_x_in_angstroms, // A
-         float wanted_particle_shift_y_in_angstroms) // A
+         float wanted_particle_shift_y_in_angstroms, // A
+         float wanted_sample_thickness_in_nm) // nm
 {
-    Init(wanted_acceleration_voltage, wanted_spherical_aberration, wanted_amplitude_contrast, wanted_defocus_1_in_angstroms, wanted_defocus_2_in_angstroms, wanted_astigmatism_azimuth, wanted_lowest_frequency_for_fitting, wanted_highest_frequency_for_fitting, wanted_astigmatism_tolerance, pixel_size, wanted_additional_phase_shift_in_radians, wanted_beam_tilt_x_in_radians, wanted_beam_tilt_y_in_radians, wanted_particle_shift_x_in_angstroms, wanted_particle_shift_y_in_angstroms);
+    Init(wanted_acceleration_voltage, wanted_spherical_aberration, wanted_amplitude_contrast, wanted_defocus_1_in_angstroms, wanted_defocus_2_in_angstroms, wanted_astigmatism_azimuth, wanted_lowest_frequency_for_fitting, wanted_highest_frequency_for_fitting, wanted_astigmatism_tolerance, pixel_size, wanted_additional_phase_shift_in_radians, wanted_beam_tilt_x_in_radians, wanted_beam_tilt_y_in_radians, wanted_particle_shift_x_in_angstroms, wanted_particle_shift_y_in_angstroms, wanted_sample_thickness_in_nm);
 }
 
 CTF::CTF(float wanted_acceleration_voltage, // keV
@@ -62,9 +64,10 @@ CTF::CTF(float wanted_acceleration_voltage, // keV
          float wanted_beam_tilt_x_in_radians, // rad
          float wanted_beam_tilt_y_in_radians, // rad
          float wanted_particle_shift_x_in_angstroms, // A
-         float wanted_particle_shift_y_in_angstroms) // A
+         float wanted_particle_shift_y_in_angstroms, // A
+         float wanted_samples_thickness_in_nm) // nm
 {
-    Init(wanted_acceleration_voltage, wanted_spherical_aberration, wanted_amplitude_contrast, wanted_defocus_1_in_angstroms, wanted_defocus_2_in_angstroms, wanted_astigmatism_azimuth, 0.0, 1.0 / (2.0 * pixel_size), -10.0, pixel_size, wanted_additional_phase_shift_in_radians, wanted_beam_tilt_x_in_radians, wanted_beam_tilt_y_in_radians, wanted_particle_shift_x_in_angstroms, wanted_particle_shift_y_in_angstroms);
+    Init(wanted_acceleration_voltage, wanted_spherical_aberration, wanted_amplitude_contrast, wanted_defocus_1_in_angstroms, wanted_defocus_2_in_angstroms, wanted_astigmatism_azimuth, 0.0, 1.0 / (2.0 * pixel_size), -10.0, pixel_size, wanted_additional_phase_shift_in_radians, wanted_beam_tilt_x_in_radians, wanted_beam_tilt_y_in_radians, wanted_particle_shift_x_in_angstroms, wanted_particle_shift_y_in_angstroms, wanted_samples_thickness_in_nm);
 }
 
 CTF::~CTF( ) {
@@ -78,9 +81,10 @@ void CTF::Init(float wanted_acceleration_voltage_in_kV, // keV
                float wanted_defocus_2_in_angstroms, // A
                float wanted_astigmatism_azimuth_in_degrees, // degrees
                float pixel_size_in_angstroms, // A
-               float wanted_additional_phase_shift_in_radians) // rad
+               float wanted_additional_phase_shift_in_radians, // rad
+               float wanted_sample_thickness_in_nm) // nm
 {
-    Init(wanted_acceleration_voltage_in_kV, wanted_spherical_aberration_in_mm, wanted_amplitude_contrast, wanted_defocus_1_in_angstroms, wanted_defocus_2_in_angstroms, wanted_astigmatism_azimuth_in_degrees, 0.0, 1.0 / (2.0 * pixel_size_in_angstroms), -10.0, pixel_size_in_angstroms, wanted_additional_phase_shift_in_radians, 0.0f, 0.0f, 0.0f, 0.0f);
+    Init(wanted_acceleration_voltage_in_kV, wanted_spherical_aberration_in_mm, wanted_amplitude_contrast, wanted_defocus_1_in_angstroms, wanted_defocus_2_in_angstroms, wanted_astigmatism_azimuth_in_degrees, 0.0, 1.0 / (2.0 * pixel_size_in_angstroms), -10.0, pixel_size_in_angstroms, wanted_additional_phase_shift_in_radians, 0.0f, 0.0f, 0.0f, 0.0f, wanted_sample_thickness_in_nm);
 }
 
 // Initialise a CTF object
@@ -98,7 +102,8 @@ void CTF::Init(float wanted_acceleration_voltage_in_kV, // keV
                float wanted_beam_tilt_x_in_radians, // rad
                float wanted_beam_tilt_y_in_radians, // rad
                float wanted_particle_shift_x_in_angstroms, // A
-               float wanted_particle_shift_y_in_angstroms) // A
+               float wanted_particle_shift_y_in_angstroms, // A
+               float wanted_sample_thickness_in_nm) // nm
 {
     wavelength                    = WavelengthGivenAccelerationVoltage(wanted_acceleration_voltage_in_kV) / pixel_size_in_angstroms;
     squared_wavelength            = powf(wavelength, 2);
@@ -112,6 +117,7 @@ void CTF::Init(float wanted_acceleration_voltage_in_kV, // keV
     lowest_frequency_for_fitting  = wanted_lowest_frequency_for_fitting_in_reciprocal_angstroms * pixel_size_in_angstroms;
     highest_frequency_for_fitting = wanted_highest_frequency_for_fitting_in_reciprocal_angstroms * pixel_size_in_angstroms;
     astigmatism_tolerance         = wanted_astigmatism_tolerance_in_angstroms / pixel_size_in_angstroms;
+    sample_thickness              = wanted_sample_thickness_in_nm * 10.0 / pixel_size_in_angstroms;
 
     // gcc catches the zero division somehow, but intel returns a nan. Needed for handling the real and complex terms of the CTF separately.
     if ( fabs(amplitude_contrast - 1.0) < 1e-3 )
@@ -378,6 +384,10 @@ void CTF::SetLowResolutionContrast(float wanted_low_resolution_contrast) {
     low_resolution_contrast = asin(wanted_low_resolution_contrast);
 }
 
+void CTF::SetSampleThickness(float wanted_sample_thickness_in_pixels) {
+    sample_thickness = wanted_sample_thickness_in_pixels;
+}
+
 // Return the value of the CTF at the given squared spatial frequency and azimuth
 std::complex<float> CTF::EvaluateComplex(float squared_spatial_frequency, float azimuth) {
     float phase_aberration = PhaseShiftGivenSquaredSpatialFrequencyAndAzimuth(squared_spatial_frequency, azimuth);
@@ -408,6 +418,13 @@ float CTF::Evaluate(float squared_spatial_frequency, float azimuth) {
                 return -sinf(phase_shift + low_resolution_contrast * (threshold - phase_shift) / threshold);
         }
     }
+}
+
+// Return the value of the CTF at the given squared spatial frequency and azimuth taken into account the sample thickness
+// Formulas according to "TEM bright field imaging of thick specimens: nodes in Thon ring patterns" by Tichelaar, et.al.
+float CTF::EvaluateWithThickness(float squared_spatial_frequency, float azimuth) {
+    float phase_aberration = PhaseShiftGivenSquaredSpatialFrequencyAndAzimuth(squared_spatial_frequency, azimuth);
+    return 0.5f * (1 - sinc_xi(squared_spatial_frequency) * cosf(2 * phase_aberration));
 }
 
 // Return the value of the CTF at the given squared spatial frequency and azimuth

--- a/src/core/ctf.h
+++ b/src/core/ctf.h
@@ -9,6 +9,7 @@ class CTF {
     float defocus_half_range;
     float astigmatism_azimuth;
     float additional_phase_shift;
+    float sample_thickness; // pixels
     float beam_tilt_x; // rad
     float beam_tilt_y; // rad
     float beam_tilt; // rad
@@ -48,7 +49,8 @@ class CTF {
         float beam_tilt_x      = 0.0f,
         float beam_tilt_y      = 0.0f,
         float particle_shift_x = 0.0f,
-        float particle_shift_y = 0.0f);
+        float particle_shift_y = 0.0f,
+        float sample_thickness = 0.0f);
 
     CTF(float wanted_acceleration_voltage, // keV
         float wanted_spherical_aberration, // mm
@@ -61,7 +63,8 @@ class CTF {
         float wanted_beam_tilt_x_in_radians        = 0.0f, // rad
         float wanted_beam_tilt_y_in_radians        = 0.0f, // rad
         float wanted_particle_shift_x_in_angstroms = 0.0f, // A
-        float wanted_particle_shift_y_in_angstroms = 0.0f); // A
+        float wanted_particle_shift_y_in_angstroms = 0.0f, // A
+        float wanted_sample_thickness_in_nms       = 0.0f); // nm
 
     ~CTF( );
 
@@ -79,7 +82,8 @@ class CTF {
               float wanted_beam_tilt_x_in_radians        = 0.0f, // rad
               float wanted_beam_tilt_y_in_radians        = 0.0f, // rad
               float wanted_particle_shift_x_in_angstroms = 0.0f, // A
-              float wanted_particle_shift_y_in_angstroms = 0.0f); // A
+              float wanted_particle_shift_y_in_angstroms = 0.0f, // A
+              float wanted_sample_thickness_in_nms       = 0.0f); // nm
 
     void Init(float wanted_acceleration_voltage_in_kV, // keV
               float wanted_spherical_aberration_in_mm, // mm
@@ -88,7 +92,8 @@ class CTF {
               float wanted_defocus_2_in_angstroms, //A
               float wanted_astigmatism_azimuth_in_degrees, // degrees
               float pixel_size_in_angstroms, // A
-              float wanted_additional_phase_shift_in_radians); //rad
+              float wanted_additional_phase_shift_in_radians, // rad
+              float wanted_sample_thickness_in_nms = 0.0f); //nm
 
     void SetDefocus(float wanted_defocus_1_pixels, float wanted_defocus_2_pixels, float wanted_astigmatism_angle_radians);
     void SetAdditionalPhaseShift(float wanted_additional_phase_shift_radians);
@@ -96,12 +101,15 @@ class CTF {
     void SetBeamTilt(float wanted_beam_tilt_x_in_radians, float wanted_beam_tilt_y_in_radians, float wanted_particle_shift_x_in_pixels = 0.0f, float wanted_particle_shift_y_in_pixels = 0.0f);
     void SetHighestFrequencyForFitting(float wanted_highest_frequency_in_reciprocal_pixels);
     void SetLowResolutionContrast(float wanted_low_resolution_contrast);
+    void SetSampleThickness(float wanted_sample_thickness_in_pixels);
 
     inline void SetHighestFrequencyWithGoodFit(float wanted_frequency_in_reciprocal_pixels) { highest_frequency_with_good_fit = wanted_frequency_in_reciprocal_pixels; };
 
     //
     std::complex<float> EvaluateComplex(float squared_spatial_frequency, float azimuth);
     float               Evaluate(float squared_spatial_frequency, float azimuth);
+    float               EvaluateWithThickness(float squared_spatial_frequency, float azimuth);
+
     float               EvaluateWithEnvelope(float squared_spatial_frequency, float azimuth);
     float               PhaseShiftGivenSquaredSpatialFrequencyAndAzimuth(float squared_spatial_frequency, float azimuth);
     std::complex<float> EvaluateBeamTiltPhaseShift(float squared_spatial_frequency, float azimuth);
@@ -111,6 +119,18 @@ class CTF {
     float               BeamTiltGivenAzimuth(float azimuth);
     float               ParticleShiftGivenAzimuth(float azimuth);
     float               WavelengthGivenAccelerationVoltage(float acceleration_voltage);
+
+    inline float xi(float squared_spatial_frequency) {
+        return PIf * wavelength * squared_spatial_frequency * sample_thickness;
+    };
+
+    inline float sinc_xi(float squared_spatial_frequency) {
+        if ( sample_thickness < 0.0001 )
+            return 1.0;
+        if ( squared_spatial_frequency < 0.000001 )
+            return 1.0;
+        return sinf(xi(squared_spatial_frequency)) / xi(squared_spatial_frequency);
+    };
 
     inline float GetLowestFrequencyForFitting( ) { return lowest_frequency_for_fitting; };
 

--- a/src/core/curve.cpp
+++ b/src/core/curve.cpp
@@ -644,6 +644,14 @@ void Curve::ApplyCTF(CTF ctf_to_apply, float azimuth_in_radians) {
     }
 }
 
+void Curve::ApplyCTFWithThickness(CTF ctf_to_apply, float azimuth_in_radians) {
+    MyDebugAssertTrue(number_of_points > 0, "No points in curve");
+
+    for ( int counter = 0; counter < number_of_points; counter++ ) {
+        data_y[counter] *= ctf_to_apply.EvaluateWithThickness(powf(data_x[counter], 2), azimuth_in_radians);
+    }
+}
+
 void Curve::ApplyGaussianLowPassFilter(float sigma) // Assumption is that X is recipricoal pixels
 {
     float frequency_squared;
@@ -945,6 +953,28 @@ void Curve::Reciprocal( ) {
     for ( int counter = 0; counter < number_of_points; counter++ ) {
         if ( data_y[counter] != 0.0 )
             data_y[counter] = 1.0 / data_y[counter];
+    }
+}
+
+void Curve::Absolute( ) {
+    for ( int counter = 0; counter < number_of_points; counter++ ) {
+        data_y[counter] = fabs(data_y[counter]);
+    }
+}
+
+bool Curve::YIsAlmostEqual(Curve& other_curve) {
+    MyDebugAssertTrue(number_of_points > 0, "No points in curve");
+    MyDebugAssertTrue(number_of_points == other_curve.number_of_points, "Number of points in curves not equal");
+    for ( int counter = 0; counter < number_of_points; counter++ ) {
+        if ( ! FloatsAreAlmostTheSame(data_y[counter], other_curve.data_y[counter]) )
+            return false;
+    }
+    return true;
+}
+
+void Curve::AddConstant(float constant_to_add) {
+    for ( int counter = 0; counter < number_of_points; counter++ ) {
+        data_y[counter] += constant_to_add;
     }
 }
 

--- a/src/core/curve.h
+++ b/src/core/curve.h
@@ -71,6 +71,7 @@ class Curve {
     void       Ln( );
     void       ZeroYData( );
     void       ApplyCTF(CTF ctf_to_apply, float azimuth_in_radians = 0.0);
+    void       ApplyCTFWithThickness(CTF ctf_to_apply, float azimuth_in_radians = 0.0);
     void       SquareRoot( );
     void       Reciprocal( );
     void       DivideBy(Curve& other_curve);
@@ -80,6 +81,9 @@ class Curve {
     float      ReturnAverageValue( );
     void       ApplyCosineMask(float wanted_x_of_cosine_start, float wanted_cosine_width_in_x, bool undo = false);
     void       ApplyGaussianLowPassFilter(float sigma); // Assumption is that X is recipricoal pixels
+    void       Absolute( );
+    bool       YIsAlmostEqual(Curve& other_curve);
+    void       AddConstant(float constant_to_add);
 
     void GetXMinMax(float& min_value, float& max_value);
     void GetYMinMax(float& min_value, float& max_value);

--- a/src/programs/gui_test/CMakeLists.txt
+++ b/src/programs/gui_test/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(gui_test gui_test.cpp)
+
+add_dependencies(gui_test cisTEM_core)
+add_dependencies(gui_test cisTEM_gui_core)
+
+target_link_libraries(gui_test    cisTEM_core 
+                                cisTEM_gui_core)
+
+
+install(TARGETS gui_test
+RUNTIME DESTINATION bin)

--- a/src/programs/gui_test/gui_test.cpp
+++ b/src/programs/gui_test/gui_test.cpp
@@ -1,0 +1,88 @@
+#include "../../core/gui_core_headers.h"
+
+class
+        GuiTestApp : public wxApp {
+
+  public:
+    virtual bool OnInit( );
+    virtual int  OnExit( );
+};
+
+IMPLEMENT_APP(GuiTestApp)
+
+PlotCurvePanel* plot_panel;
+
+class GuiTestMainFrame : public wxFrame {
+  public:
+    GuiTestMainFrame(const wxString& title, const wxPoint& pos, const wxSize& size);
+
+  private:
+    //void OnHello(wxCommandEvent& event);
+    //void OnExit(wxCommandEvent& event);
+    //void OnAbout(wxCommandEvent& event);
+    //wxDECLARE_EVENT_TABLE( );
+};
+
+GuiTestMainFrame::GuiTestMainFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
+    : wxFrame(NULL, wxID_ANY, title, pos, size) {
+
+    plot_panel = new PlotCurvePanel((wxWindow*)this);
+    wxBoxSizer* bSizer2;
+    bSizer2 = new wxBoxSizer(wxVERTICAL);
+    bSizer2->Add(plot_panel, 1, wxEXPAND | wxALL, 5);
+    this->SetSizer(bSizer2);
+    this->Layout( );
+
+    CTF ctf;
+    // CTF with a sample thickness parameter of 100.0
+    ctf.Init(300, 2.7, 0.07, 5000, 5000, 0, 1.0, 0.0, 100.0);
+
+    Curve ctf_curve;
+    ctf_curve.SetupXAxis(0.0, 0.5, 500);
+    ctf_curve.SetYToConstant(1.0);
+
+    ctf_curve.ApplyCTFWithThickness(ctf, 0.0);
+
+    Curve ctf_curve3, ctf_curve1;
+    ctf_curve3.SetupXAxis(0.0, 0.5, 500);
+    ctf_curve1.SetupXAxis(0.0, 0.5, 500);
+    ctf_curve1.SetYToConstant(0.0);
+
+    int counter = 0;
+    CTF ctf1;
+    for ( float z_level = -495.0; z_level < 500.0; z_level = z_level + 10.0f ) {
+        ctf1.Init(300, 2.7, 0.07, 5000 + z_level, 5000 + z_level, 0, 1.0, 0.0, 0.0);
+        counter++;
+        ctf_curve3.SetYToConstant(1.0);
+        ctf_curve3.ApplyCTF(ctf1);
+        ctf_curve3.MultiplyBy(ctf_curve3);
+        ctf_curve1.AddWith(&ctf_curve3);
+    }
+    ctf_curve1.MultiplyByConstant(1.0f / counter);
+
+    plot_panel->Initialise("Resolution", "CTF", false, true);
+    //Bit of offset for vis
+    ctf_curve1.AddConstant(0.01);
+    plot_panel->AddCurve(ctf_curve, *wxBLUE);
+    plot_panel->AddCurve(ctf_curve1, *wxRED);
+
+    plot_panel->Draw( );
+
+    CreateStatusBar( );
+    SetStatusText("Test 001");
+}
+
+GuiTestMainFrame* gui_test_main_frame;
+
+bool GuiTestApp::OnInit( ) {
+    gui_test_main_frame = new GuiTestMainFrame("GUI Test", wxPoint(50, 50), wxSize(450, 340));
+
+    gui_test_main_frame->Show(true);
+
+    return true;
+}
+
+int GuiTestApp::OnExit( ) {
+
+    return 0;
+}


### PR DESCRIPTION
# Description

This adds the `sample_thickness` attribute to the ctf class, which can be used to generate CTFs affected by sample thickness using the `EvaluateWithThickness` methods as described by Tichelaar et.al. Ultramicroscopy 2020.

There are some sanity checks in console_test. I also added some convenience functions to the curve class and a new test app called gui_test. For now it just shows a plot of a node-containing ctf, but I thought it could be extended to test other graphical things.

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [x] Tested manually from CLI
- [x] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
