### PR TITLE
[Fix] Increase MaxJobWaitTime for match_template

### DIFF
--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -52,7 +52,7 @@ class
     ArrayOfAggregatedTemplateResults aggregated_results;
     bool                             is_rotated_by_90 = false;
 
-    float GetMaxJobWaitTimeInSeconds( ) { return 120.0f; }
+    float GetMaxJobWaitTimeInSeconds( ) { return 360.0f; }
 
   private:
 };


### PR DESCRIPTION
# Description

I have been trying to run match_template through the GUI on 96 GPUs. This very quickly results in many workers disconnecting, because they have not recieved a Job. I poked around a bit and it seems like the main_thread in the master becomes bogged down with combining the partial results (which all come in around the same time) so that it does not send out new jobs fast enough. This partially fixes that, even though not in the most satisfying way.

After this change 96 GPUs still do not work (but 64 do). Now workers disconnect because they complain that the master thread did not read all bytes of their DefinedResult. This might also be related with the master having to deal with too many results at a time. There might be another timeout that we can tweak, but at that point it seems like we should think about better ways to do this. Maybe there can be a pyramid of leaders and workers (for example every 10 workers have a intermediate leader which then report to the master).

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
