### PR TITLE
[Fix] 90 degree rotate bug

### DIFF
--- a/src/programs/match_template/match_template.cpp
+++ b/src/programs/match_template/match_template.cpp
@@ -560,6 +560,7 @@ bool MatchTemplateApp::DoCalculation( ) {
             if ( ReturnThreadNumberOfCurrentThread( ) == 0 ) {
                 wxPrintf("Not rotating the search image for speed even though it is enabled\n");
             }
+            is_rotated_by_90 = false;
         }
 #endif
     }


### PR DESCRIPTION
# Description

I had recently seen many mips like this:

![image](https://user-images.githubusercontent.com/6081039/202927882-c5875f86-ea53-4d4f-8a60-5196fc09bd3e.png)

which clearly look like there is something weird going on, where the normalization is rotated by 90 degrees.

The problem is in the logic to rotate images by 90 degrees if it increases the search speed. The problem is that the `is_rotated_by_90` bool is a class attribute of the application that is set to true if an image is deemed suitable for orientation.

https://github.com/timothygrant80/cisTEM/blob/261481a6f90ec7a602b3a181c57b93ca84b989b4/src/programs/match_template/match_template.cpp#L546-L563

However, if the `if` statement is not triggered  `is_rotated_by_90` is not being set to false. So if a worker first processes a "rotatable" image and then a "non-rotatable" image the bool will remain true. This means that this code at the end gets triggered:

https://github.com/timothygrant80/cisTEM/blob/261481a6f90ec7a602b3a181c57b93ca84b989b4/src/programs/match_template/match_template.cpp#L1089-L1109

and everything gets rotated even though the image never did. 

This is fixed by simply setting `is_rotated_by_90` if the image is not suitable for orientation. Alternatively we could declare and assign it in the `DoCalculation` method instead of it being a class attribute.

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
