### PR TITLE
Use right mask radius in for fourier inner mask of CosineRingMask

### DIFF
--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -3296,13 +3296,13 @@ float Image::CosineRingMask(float wanted_inner_radius, float wanted_outer_radius
                     if ( do_inner_masking ) {
                         if ( frequency_squared <= inner_mask_radius_squared && frequency_squared >= inner_mask_radius_minus_edge_squared ) {
                             frequency = sqrtf(frequency_squared);
-                            edge      = (1.0 + cosf(PI * (outer_mask_radius - frequency) / wanted_mask_edge)) / 2.0;
+                            edge      = (1.0 + cosf(PI * (inner_mask_radius - frequency) / wanted_mask_edge)) / 2.0;
                             complex_values[pixel_counter] *= edge;
                         }
-                        if ( frequency_squared <= inner_mask_radius_minus_edge_squared )
-                            complex_values[pixel_counter] = 0.0f + I * 0.0f;
+                        if ( frequency_squared <= inner_mask_radius_minus_edge_squared ) 
+                            complex_values[pixel_counter] = 0.0f + I * 0.0f;     
                     }
-
+                    
                     if ( frequency_squared >= outer_mask_radius_plus_edge_squared )
                         complex_values[pixel_counter] = 0.0f + I * 0.0f;
 


### PR DESCRIPTION
# Description

This is a fix for a bug Niko found.


# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
