### PR TITLE
Fixes (Gpu)Image::SwapRealSpaceQuadrants() for odd sized images.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ devcontainer.json
 cistem_config.in*
 scripts/testing/post_format_test.cpp
 src/ext/
+configure~
+*.mrc
+*.tif
+*.dff

--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -174,6 +174,16 @@ float Image::ReturnSumOfRealValues( ) {
     return float(sum);
 }
 
+/**
+ * @brief Warning: This function returns the Sum of Squares in Fourier space, SS/N in real space
+ * 
+ * @param wanted_mask_radius 
+ * @param wanted_center_x 
+ * @param wanted_center_y 
+ * @param wanted_center_z 
+ * @param invert_mask 
+ * @return float 
+ */
 float Image::ReturnSumOfSquares(float wanted_mask_radius, float wanted_center_x, float wanted_center_y, float wanted_center_z, bool invert_mask) {
     //	result is too big
     MyDebugAssertTrue(is_in_memory, "Memory not allocated");
@@ -273,7 +283,7 @@ float Image::ReturnSumOfSquares(float wanted_mask_radius, float wanted_center_x,
                     if ( (i == 0 || (i == logical_upper_bound_complex_x && x_is_even)) && (jj == 0 || (jj == logical_lower_bound_complex_y && x_is_even)) && (kk == 0 || (kk == logical_lower_bound_complex_z && x_is_even)) )
                         sum += pow(abs(complex_values[address]), 2) * 0.5;
                     else if ( (i == 0 || (i == logical_upper_bound_complex_x && x_is_even)) && logical_z_dimension != 1 )
-                        sum += pow(abs(complex_values[address]), 2) * 0.25;
+                        sum += pow(abs(complex_values[address]), 2) * 0.5f;
                     else if ( (i != 0 && (i != logical_upper_bound_complex_x || ! x_is_even)) || (jj >= 0 && kk >= 0) )
                         sum += pow(abs(complex_values[address]), 2);
                     address++;
@@ -2335,6 +2345,16 @@ void Image::RotateFourier2D(Image& rotated_image, AnglesAndShifts& rotation_angl
     rotated_image.object_is_centred_in_box = false;
 }
 
+/**
+ * @brief Extract a 2d central section at arbitrary angles and shifts from (this) 3d volume.
+ * Requires the 3d volume to be cubic and origin at the corner, i.e. QuadrantSwapped.
+ * Output is the FFT of the extracted 2d image, QuadrantSwapped with zero mean.
+ * 
+ * @param image_to_extract 
+ * @param angles_and_shifts_of_image 
+ * @param resolution_limit 
+ * @param apply_resolution_limit 
+ */
 void Image::ExtractSlice(Image& image_to_extract, AnglesAndShifts& angles_and_shifts_of_image, float resolution_limit, bool apply_resolution_limit) {
     //	MyDebugAssertTrue(image_to_extract.logical_x_dimension == logical_x_dimension && image_to_extract.logical_y_dimension == logical_y_dimension, "Error: Images different sizes");
     MyDebugAssertTrue(image_to_extract.logical_z_dimension == 1, "Error: attempting to extract 3D image from 3D reconstruction");
@@ -4428,10 +4448,17 @@ void Image::Deallocate( ) {
 #endif
 }
 
-//!>  \brief  Allocate memory for the Image object.
-//
-//  If the object is already allocated with correct dimensions, nothing happens. Otherwise, object is deallocated first.
-
+/**
+ * @brief Allocate memory for the Image object.
+ * If the object is already allocated with correct dimensions, nothing happens. Otherwise, object is deallocated first.
+ * Warning: if the object is deallocated/reallocated the value of object_is_centred_in_box is NOT reset. And must be done manually.
+ * TODO: It is worth considering reseting all metadata bools to default in the Image::Deallocate() method.
+ * @param wanted_x_size 
+ * @param wanted_y_size 
+ * @param wanted_z_size 
+ * @param should_be_in_real_space 
+ * @param do_fft_planning 
+ */
 void Image::Allocate(int wanted_x_size, int wanted_y_size, int wanted_z_size, bool should_be_in_real_space, bool do_fft_planning) {
 
     MyDebugAssertTrue(wanted_x_size > 0 && wanted_y_size > 0 && wanted_z_size > 0, "Bad dimensions: %i %i %i\n", wanted_x_size, wanted_y_size, wanted_z_size);
@@ -4684,7 +4711,7 @@ void Image::UpdateLoopingAndAddressing( ) {
 
 void Image::UpdatePhysicalAddressOfBoxCenter( ) {
     /*
-    if (IsEven(logical_x_dimension)) physical_address_of_box_center_x = logical_x_dimension / 2;
+    if (IsEven(logical_x_dimension))  = logical_x_dimension / 2;
     else physical_address_of_box_center_x = (logical_x_dimension - 1) / 2;
 
     if (IsEven(logical_y_dimension)) physical_address_of_box_center_y = logical_y_dimension / 2;

--- a/src/core/image.cpp
+++ b/src/core/image.cpp
@@ -9015,6 +9015,10 @@ void Image::SwapFourierSpaceQuadrants(bool also_swap_real_space_quadrants) {
     is_fft_centered_in_box = true;
 }
 
+/**
+ * @brief Places the origin of the image (N/2) at 0,0,0 in real space. And vice-versa. Applied twice in a row should be a noop.
+ * 
+ */
 void Image::SwapRealSpaceQuadrants( ) {
     MyDebugAssertTrue(is_in_memory, "Memory not allocated");
 
@@ -9024,50 +9028,44 @@ void Image::SwapRealSpaceQuadrants( ) {
     float y_shift_to_apply;
     float z_shift_to_apply;
 
-    if ( is_in_real_space == true ) {
+    if ( is_in_real_space ) {
         must_fft = true;
         ForwardFFT( );
     }
 
-    if ( object_is_centred_in_box == true ) {
+    if ( object_is_centred_in_box ) {
+
+        if ( IsEven(logical_x_dimension) )
+            x_shift_to_apply = float(physical_address_of_box_center_x);
+        else
+            x_shift_to_apply = float(physical_address_of_box_center_x) + 1.0f;
+
+        if ( IsEven(logical_y_dimension) )
+            y_shift_to_apply = float(physical_address_of_box_center_y);
+        else
+            y_shift_to_apply = float(physical_address_of_box_center_y) + 1.0f;
+
+        if ( IsEven(logical_z_dimension) )
+            z_shift_to_apply = float(physical_address_of_box_center_z);
+        else
+            z_shift_to_apply = float(physical_address_of_box_center_z) + 1.0f;
+    }
+    else {
         x_shift_to_apply = float(physical_address_of_box_center_x);
         y_shift_to_apply = float(physical_address_of_box_center_y);
         z_shift_to_apply = float(physical_address_of_box_center_z);
     }
-    else {
-        if ( IsEven(logical_x_dimension) == true ) {
-            x_shift_to_apply = float(physical_address_of_box_center_x);
-        }
-        else {
-            x_shift_to_apply = float(physical_address_of_box_center_x) - 1.0;
-        }
 
-        if ( IsEven(logical_y_dimension) == true ) {
-            y_shift_to_apply = float(physical_address_of_box_center_y);
-        }
-        else {
-            y_shift_to_apply = float(physical_address_of_box_center_y) - 1.0;
-        }
-
-        if ( IsEven(logical_z_dimension) == true ) {
-            z_shift_to_apply = float(physical_address_of_box_center_z);
-        }
-        else {
-            z_shift_to_apply = float(physical_address_of_box_center_z) - 1.0;
-        }
-    }
-
-    if ( logical_z_dimension == 1 ) {
+    if ( logical_z_dimension == 1 )
         z_shift_to_apply = 0.0;
-    }
 
     PhaseShift(x_shift_to_apply, y_shift_to_apply, z_shift_to_apply);
 
-    if ( must_fft == true )
+    if ( must_fft )
         BackwardFFT( );
 
     // keep track of center;
-    if ( object_is_centred_in_box == true )
+    if ( object_is_centred_in_box )
         object_is_centred_in_box = false;
     else
         object_is_centred_in_box = true;

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -789,6 +789,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_sum:
             if ( ! is_allocated_sum_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiSumGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->sum_buffer, n_elem, nppStream.hStream));
@@ -798,6 +799,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_min:
             if ( ! is_allocated_min_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMinGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->min_buffer, n_elem, nppStream.hStream));
@@ -808,6 +810,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_minIDX:
             if ( ! is_allocated_minIDX_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMinIndxGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->minIDX_buffer, n_elem, nppStream.hStream));
@@ -818,6 +821,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_max:
             if ( ! is_allocated_max_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMaxGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->max_buffer, n_elem, nppStream.hStream));
@@ -828,6 +832,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_maxIDX:
             if ( ! is_allocated_maxIDX_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMaxIndxGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->maxIDX_buffer, n_elem, nppStream.hStream));
@@ -838,6 +843,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_minmax:
             if ( ! is_allocated_minmax_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMinMaxGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->minmax_buffer, n_elem, nppStream.hStream));
@@ -848,6 +854,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_minmaxIDX:
             if ( ! is_allocated_minmaxIDX_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMinMaxIndxGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->minmaxIDX_buffer, n_elem, nppStream.hStream));
@@ -858,6 +865,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_mean:
             if ( ! is_allocated_mean_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMeanGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->mean_buffer, n_elem, nppStream.hStream));
@@ -867,6 +875,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
             break;
         case b_meanstddev:
             if ( ! is_allocated_meanstddev_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiMeanStdDevGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaStreamSynchronize(nppStream.hStream));
@@ -878,6 +887,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_countinrange:
             if ( ! is_allocated_countinrange_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiCountInRangeGetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->countinrange_buffer, n_elem, nppStream.hStream));
@@ -888,6 +898,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_l2norm:
             if ( ! is_allocated_l2norm_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiNormL2GetBufferHostSize_32f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->l2norm_buffer, n_elem, nppStream.hStream));
@@ -898,6 +909,7 @@ void GpuImage::BufferInit(BufferType bt, int n_elements) {
 
         case b_dotproduct:
             if ( ! is_allocated_dotproduct_buffer ) {
+                MyDebugAssertTrue(is_npp_loaded, "Error: NPP not loaded");
                 int n_elem;
                 nppErr(nppiDotProdGetBufferHostSize_32f64f_C1R_Ctx(npp_ROI, &n_elem, nppStream));
                 cudaErr(cudaMallocAsync(&this->dotproduct_buffer, n_elem, nppStream.hStream));
@@ -1081,10 +1093,10 @@ void GpuImage::BufferDestroy( ) {
 float GpuImage::ReturnSumOfSquares( ) {
     // FIXME this assumes padded values are zero which is not strictly true
     MyDebugAssertTrue(is_in_memory_gpu, "Image not allocated");
-    MyDebugAssertTrue(is_in_real_space, "This method is for real space, use ReturnSumSquareModulusComplexValues for Fourier space")
+    MyDebugAssertTrue(is_in_real_space, "This method is for real space, use ReturnSumSquareModulusComplexValues for Fourier space");
 
-            BufferInit(b_l2norm);
     NppInit( );
+    BufferInit(b_l2norm);
 
     nppErr(nppiNorm_L2_32f_C1R_Ctx((Npp32f*)real_values, pitch, npp_ROI,
                                    (Npp64f*)tmpValComplex, (Npp8u*)this->l2norm_buffer, nppStream));
@@ -1186,8 +1198,8 @@ float GpuImage::ReturnSumSquareModulusComplexValues( ) {
     // With real and complex interleaved, treating as real is equivalent to taking the conj dot prod
     precheck;
 
-    BufferInit(b_l2norm);
     NppInit( );
+    BufferInit(b_l2norm);
     nppErr(nppiNorm_L2_32f_C1R_Ctx((Npp32f*)image_buffer->real_values, pitch, npp_ROI_fourier_with_real_functor,
                                    (Npp64f*)tmpValComplex, (Npp8u*)this->l2norm_buffer, nppStream));
 
@@ -2150,8 +2162,8 @@ void GpuImage::Abs( ) {
 void GpuImage::AbsDiff(GpuImage& other_image) {
     MyDebugAssertTrue(HasSameDimensionsAs(&other_image), "Images have different dimension.");
 
-    BufferInit(b_image);
     NppInit( );
+    BufferInit(b_image);
 
     nppErr(nppiAbsDiff_32f_C1R_Ctx((const Npp32f*)real_values, pitch,
                                    (const Npp32f*)other_image.real_values, pitch,
@@ -2346,9 +2358,9 @@ void GpuImage::AddConstant(const float add_val) {
 
 void GpuImage::AddConstant(const Npp32fc add_val) {
     MyDebugAssertTrue(is_in_memory_gpu, "Memory not allocated");
-    MyDebugAssertTrue(is_in_real_space, "Image in real space.")
+    MyDebugAssertTrue(is_in_real_space, "Image in real space.");
 
-            NppInit( );
+    NppInit( );
     nppErr(nppiAddC_32fc_C1IR_Ctx((Npp32fc)add_val, (Npp32fc*)complex_values, pitch, npp_ROI, nppStream));
 }
 
@@ -3146,6 +3158,10 @@ void GpuImage::RecordAndWait( ) {
     Wait( );
 }
 
+/**
+ * @brief Places the origin of the image (N/2) at 0,0,0 in real space. And vice-versa. Applied twice in a row should be a noop.
+ * 
+ */
 template <typename StorageTypeBase>
 void GpuImage::SwapRealSpaceQuadrants( ) {
     if constexpr ( std::is_same<StorageTypeBase, __half>::value ) {
@@ -3162,37 +3178,32 @@ void GpuImage::SwapRealSpaceQuadrants( ) {
     float y_shift_to_apply;
     float z_shift_to_apply;
 
-    if ( is_in_real_space == true ) {
+    if ( is_in_real_space ) {
         must_fft = true;
         ForwardFFT(true);
     }
 
-    if ( object_is_centred_in_box == true ) {
+    if ( object_is_centred_in_box ) {
+        if ( IsEven(dims.x) )
+            x_shift_to_apply = float(physical_address_of_box_center.x);
+        else
+            x_shift_to_apply = float(physical_address_of_box_center.x) + 1.0f;
+
+        if ( IsEven(dims.y) )
+            y_shift_to_apply = float(physical_address_of_box_center.y);
+        else
+            y_shift_to_apply = float(physical_address_of_box_center.y) + 1.0f;
+
+        if ( IsEven(dims.z) )
+            z_shift_to_apply = float(physical_address_of_box_center.z);
+        else
+            z_shift_to_apply = float(physical_address_of_box_center.z) + 1.0f;
+    }
+    else {
+
         x_shift_to_apply = float(physical_address_of_box_center.x);
         y_shift_to_apply = float(physical_address_of_box_center.y);
         z_shift_to_apply = float(physical_address_of_box_center.z);
-    }
-    else {
-        if ( IsEven(dims.x) == true ) {
-            x_shift_to_apply = float(physical_address_of_box_center.x);
-        }
-        else {
-            x_shift_to_apply = float(physical_address_of_box_center.x) - 1.0;
-        }
-
-        if ( IsEven(dims.y) == true ) {
-            y_shift_to_apply = float(physical_address_of_box_center.y);
-        }
-        else {
-            y_shift_to_apply = float(physical_address_of_box_center.y) - 1.0;
-        }
-
-        if ( IsEven(dims.z) == true ) {
-            z_shift_to_apply = float(physical_address_of_box_center.z);
-        }
-        else {
-            z_shift_to_apply = float(physical_address_of_box_center.z) - 1.0;
-        }
     }
 
     if ( dims.z == 1 ) {
@@ -3201,11 +3212,11 @@ void GpuImage::SwapRealSpaceQuadrants( ) {
 
     PhaseShift<StorageTypeBase>(x_shift_to_apply, y_shift_to_apply, z_shift_to_apply);
 
-    if ( must_fft == true )
+    if ( must_fft )
         BackwardFFT( );
 
     // keep track of center;
-    if ( object_is_centred_in_box == true )
+    if ( object_is_centred_in_box )
         object_is_centred_in_box = false;
     else
         object_is_centred_in_box = true;
@@ -3270,6 +3281,15 @@ PhaseShiftKernel(StorageType* d_input,
     }
 }
 
+/**
+ * @brief Shifts an image in Fourier space forward by the given amount in pixels. 
+ * If not in Fourier space, 2 FFTs are performed.
+ * 
+ * @tparam StorageTypeBase 
+ * @param wanted_x_shift 
+ * @param wanted_y_shift 
+ * @param wanted_z_shift 
+ */
 template <typename StorageTypeBase>
 void GpuImage::PhaseShift<StorageTypeBase>(float wanted_x_shift, float wanted_y_shift, float wanted_z_shift) {
     if constexpr ( std::is_same<StorageTypeBase, __half>::value ) {

--- a/src/gpu/GpuImage.cu
+++ b/src/gpu/GpuImage.cu
@@ -2770,7 +2770,7 @@ void GpuImage::CopyHostToDeviceTextureComplex3d(Image& host_image) {
 
 // TODO: replace with template version
 void GpuImage::CopyHostToDevice16f(Image& host_image, bool should_block_until_finished) {
-    MyDebugAssertTrue(host_image.is_memory_allocated(real_values_16f), "Host image not allocated");
+    MyDebugAssertTrue(host_image.IsMemoryAllocated(real_values_16f), "Host image not allocated");
     if ( is_meta_data_initialized ) {
         MyDebugAssertTrue(HasSameDimensionsAs(host_image), "Images have different dimensions");
         UpdateFlagsFromHostImage(host_image);

--- a/src/gpu/core_extensions/image.cu
+++ b/src/gpu/core_extensions/image.cu
@@ -66,7 +66,7 @@ template void Image::RegisterPageLockedMemory<half_float::half>(half_float::half
 
 template <typename StorageBaseType>
 void Image::UnRegisterPageLockedMemory(StorageBaseType* ptr) {
-    MyDebugAssertTrue(is_memory_allocated(ptr), "Image is not in memory");
+    MyDebugAssertTrue(IsMemoryAllocated(ptr), "Image is not in memory");
 
     if ( IsMemoryPageLocked(ptr) ) {
         wxMutexLocker lock(s_mutexProtectingFFTW); // the mutex will be unlocked when this object is destroyed (when it goes out of scope)

--- a/src/gpu/gpu_core_headers.h
+++ b/src/gpu/gpu_core_headers.h
@@ -31,7 +31,7 @@ const int MAX_GPU_COUNT = 32;
 #define precheck 
 #else
 // The static path to the error code definitions is brittle, but better than the internet. At least you can click in VSCODE to get there.
-#define nppErr(npp_stat)  {if (npp_stat != NPP_SUCCESS) { std::cerr << "NPP_CHECK_NPP - npp_stat = " << npp_stat ; wxPrintf(" at %s:(%d)\nFind error codes at /usr/local/cuda-11.7/targets/x86_64-linux/include/nppdefs.h:(170)\n\n",__FILE__,__LINE__); DEBUG_ABORT} }
+#define nppErr(npp_stat)  {if (npp_stat != NPP_SUCCESS) { std::cerr << "NPP_CHECK_NPP - npp_stat = " << npp_stat ; wxPrintf(" at %s:(%d)\nFind error codes at /usr/local/cuda-11.7/targets/x86_64-linux/include/nppdefs.h:(170)\n\n",__FILE__,__LINE__); DEBUG_ABORT} ;};
 #define cudaErr(error) { auto status = static_cast<cudaError_t>(error); if (status != cudaSuccess) { std::cerr << cudaGetErrorString(status) << " :-> "; MyPrintWithDetails(""); DEBUG_ABORT} }
 #define cufftErr(error) { auto status = static_cast<cufftResult>(error); if (status != CUFFT_SUCCESS) { std::cerr << cistem::gpu::cufft_error_types[status] << " :-> "; MyPrintWithDetails(""); DEBUG_ABORT} }
 #define cuTensorErr(error) { auto status = static_cast<cutensorStatus_t>(error); if (status != CUTENSOR_STATUS_SUCCESS) { std::cerr << cutensorGetErrorString(status) << " :-> "; MyPrintWithDetails(""); DEBUG_ABORT} }

--- a/src/gpu/gpu_image_cuFFT_callbacks.h
+++ b/src/gpu/gpu_image_cuFFT_callbacks.h
@@ -1,4 +1,5 @@
-
+#ifndef __GPU_IMAGE_CUFFT_CALLBACKS_H__
+#define __GPU_IMAGE_CUFFT_CALLBACKS_H__
 
 // cuFFT callbacks
 // These must be linked with the static cuFFT library.
@@ -90,3 +91,5 @@ static __device__ cufftReal CB_realLoadAndClipInto(void* dataIn, size_t offset, 
 }
 
 __device__ cufftCallbackLoadR d_realLoadAndClipInto = CB_realLoadAndClipInto;
+
+#endif // __GPU_IMAGE_CUFFT_CALLBACKS_H__

--- a/src/programs/console_test/console_test.cpp
+++ b/src/programs/console_test/console_test.cpp
@@ -1316,7 +1316,32 @@ void MyTestApp::TestAlignmentFunctions( ) {
 
     EndTest( );
 
-    // TODO: Add SwapRealSpaceQuadrants test here. (See note above)
+    // SwapRealSpaceQuadrants
+    BeginTest("Image::SwapRealSpaceQuadrants");
+    // Test for even/odd and 2 and 3D images
+    std::array<int, 2>  test_sizes = {4, 5};
+    std::array<bool, 2> test_3d    = {false, true};
+    int                 size_z     = 0;
+    for ( auto& size : test_sizes ) {
+        for ( auto& is_3d : test_3d ) {
+            if ( is_3d )
+                size_z = size;
+            else
+                size_z = 1;
+            test_image.Allocate(size, size, size_z);
+            test_image.SetToConstant(0.0f);
+            // Set a unit impulse at the centered in the box origin
+            test_image.real_values[test_image.ReturnReal1DAddressFromPhysicalCoord(test_image.physical_address_of_box_center_x, test_image.physical_address_of_box_center_y, test_image.physical_address_of_box_center_z)] = 1.0f;
+            test_image.SwapRealSpaceQuadrants( );
+            if ( ! FloatsAreAlmostTheSame(test_image.real_values[0], 1.0f) )
+                FailTest;
+            // Swapping back should put the impulse back in the center
+            test_image.SwapRealSpaceQuadrants( );
+            if ( ! FloatsAreAlmostTheSame(test_image.ReturnRealPixelFromPhysicalCoord(test_image.physical_address_of_box_center_x, test_image.physical_address_of_box_center_y, test_image.physical_address_of_box_center_z), 1.0f) )
+                FailTest;
+        }
+    }
+    EndTest( );
 
     // CalculateCrossCorrelationImageWith
     BeginTest("Image::CalculateCrossCorrelationImageWith");


### PR DESCRIPTION
Fixes (Gpu)Image::SwapRealSpaceQuadrants() for odd sized images.

Fixes GpuImage::ReturnSumOfSquares, which was calling BufferInit before NPPInit, leaving the NPP buffer allocation based on uninitialized values.

Adds Debug asserts to catch the above scenario.

Adds testing for even/odd 2d/3d images for SwapQuadrants in console test. Only the Image class is tested, not GpuImage.

Adds include guards for gpu_image_cuFFT_callbacks.h.

Adds to git ignore some extensions for images and interactive runs (dff) when testing is done in the primary repo. This is convenient in the container where not all folders are mounted.

# Description

For odd images, applying SwapRealSpaceQuadrants twice did not return the starting image. The origin was left at the "top right" (image below with value 1 placed at box center, then SwapQuadrants applied. Expected 1 in the lower left corner.) rather than wrapping around to the "bottom left" after 1 application. The error was compounded by the -1 on the return trip. The fix is to shift 1 extra pixel from centered -> corner, then shift by N/2 on the corner->centered.

This fix could create problems if there is another method that has a compensatory error. For example Image::FindPeakAtOriginFast2D()

SwapQuadrants is used in many places, for example, to make a cross-correlation come out with the peaks centered in the box. Most interesting, and deserving a look is in interpolation, where the origin of rotation is shifted to the corner prior to interpolating. I don't see how this could have worked properly before on odd sized images.

![image](https://github.com/timothygrant80/cisTEM/assets/3077528/640f39b7-beac-4654-8b67-7f65fbc509e2)

**zoom in of an Overlay of unit impulse prior to shift, and after a round trip Swap, Swap**

![image](https://github.com/timothygrant80/cisTEM/assets/3077528/d15c40d7-3bab-4a5b-849c-08bfe4b00d4a)


Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [X] icc

# These changes are isolated to the

- [ ] gui
- [X] core library
- [X] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [X] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
