### PR TITLE
project3d now writes out parameters

### DIFF
--- a/src/programs/project3d/project3d.cpp
+++ b/src/programs/project3d/project3d.cpp
@@ -55,10 +55,10 @@ void Project3DApp::DoInteractiveUserInput( ) {
         apply_shifts        = my_input->GetYesNoFromUser("Apply shifts", "Should the particle translations be applied to the output projections?", "No");
     }
     else {
-        angular_step = my_input->GetFloatFromUser("Angular step for projection", "Angular step size for grid projection", "0.0", 0.1);
+        angular_step     = my_input->GetFloatFromUser("Angular step for projection", "Angular step size for grid projection", "0.0", 0.1);
         output_star_file = my_input->GetFilenameFromUser("Output Star File", "The star file containing angles for the projections", "output_angles.star", false);
-        apply_CTF    = false;
-        apply_shifts = false;
+        apply_CTF        = false;
+        apply_shifts     = false;
     }
 
     ouput_projection_stack = my_input->GetFilenameFromUser("Output projection stack", "The output image stack, containing the 2D projections", "my_projection_stack.mrc", false);
@@ -90,10 +90,21 @@ void Project3DApp::DoInteractiveUserInput( ) {
     my_current_job.ManualSetArguments("tttiifffftbbbbbfit", input_star_filename.ToUTF8( ).data( ),
                                       input_reconstruction.ToUTF8( ).data( ),
                                       ouput_projection_stack.ToUTF8( ).data( ),
-                                      first_particle, last_particle,
-                                      pixel_size, mask_radius, wanted_SNR, padding,
+                                      first_particle,
+                                      last_particle,
+                                      pixel_size,
+                                      mask_radius,
+                                      wanted_SNR,
+                                      padding,
                                       my_symmetry.ToUTF8( ).data( ),
-                                      apply_CTF, apply_shifts, apply_mask, add_noise, project_based_on_star, angular_step, max_threads, output_star_file.ToUTF8().data());
+                                      apply_CTF,
+                                      apply_shifts,
+                                      apply_mask,
+                                      add_noise,
+                                      project_based_on_star,
+                                      angular_step,
+                                      max_threads,
+                                      output_star_file.ToUTF8( ).data( ));
 }
 
 // override the do calculation method which will be what is actually run..
@@ -123,13 +134,13 @@ bool Project3DApp::DoCalculation( ) {
     bool     project_based_on_star = my_current_job.arguments[14].ReturnBoolArgument( );
     float    angular_step          = my_current_job.arguments[15].ReturnFloatArgument( );
     int      max_threads           = my_current_job.arguments[16].ReturnIntegerArgument( );
-    wxString output_star_file     = my_current_job.arguments[17].ReturnStringArgument( );
+    wxString output_star_file      = my_current_job.arguments[17].ReturnStringArgument( );
 
     Image               projection_image;
     Image               final_image;
     ReconstructedVolume input_3d;
     Image               projection_3d;
-    cisTEMParameters output_params;
+    cisTEMParameters    output_params;
 
     int image_counter = 0;
     int number_of_projections_to_calculate;
@@ -226,22 +237,43 @@ bool Project3DApp::DoCalculation( ) {
         wxPrintf("\nAverage sigma noise = %f, average score = %f\nNumber of projections to calculate = %li\n\n", average_sigma, average_score, lines_to_process.GetCount( ));
     }
 
-    if ( project_based_on_star == true )
+    if ( project_based_on_star ) {
         number_of_projections_to_calculate = lines_to_process.GetCount( );
-    else
-    {
+    }
+    else {
         number_of_projections_to_calculate = global_euler_search.number_of_search_positions;
 
         // setup paramters
 
-        output_params.parameters_to_write.SetActiveParameters(POSITION_IN_STACK | IMAGE_IS_ACTIVE | PSI | THETA | PHI | X_SHIFT | Y_SHIFT | DEFOCUS_1 | DEFOCUS_2 | DEFOCUS_ANGLE | PHASE_SHIFT | OCCUPANCY | LOGP | SIGMA | SCORE | PIXEL_SIZE | MICROSCOPE_VOLTAGE | MICROSCOPE_CS | AMPLITUDE_CONTRAST | BEAM_TILT_X | BEAM_TILT_Y | IMAGE_SHIFT_X | IMAGE_SHIFT_Y | ASSIGNED_SUBSET);
+        output_params.parameters_to_write.SetActiveParameters(POSITION_IN_STACK |
+                                                              IMAGE_IS_ACTIVE |
+                                                              PSI |
+                                                              THETA |
+                                                              PHI |
+                                                              X_SHIFT |
+                                                              Y_SHIFT |
+                                                              DEFOCUS_1 |
+                                                              DEFOCUS_2 |
+                                                              DEFOCUS_ANGLE |
+                                                              PHASE_SHIFT |
+                                                              OCCUPANCY |
+                                                              LOGP |
+                                                              SIGMA |
+                                                              SCORE |
+                                                              PIXEL_SIZE |
+                                                              MICROSCOPE_VOLTAGE |
+                                                              MICROSCOPE_CS |
+                                                              AMPLITUDE_CONTRAST |
+                                                              BEAM_TILT_X |
+                                                              BEAM_TILT_Y |
+                                                              IMAGE_SHIFT_X |
+                                                              IMAGE_SHIFT_Y |
+                                                              ASSIGNED_SUBSET);
         output_params.PreallocateMemoryAndBlank(number_of_projections_to_calculate);
     }
 
     ProgressBar* my_progress = new ProgressBar(number_of_projections_to_calculate);
     projection_3d.CopyFrom(input_3d.density_map);
-
-
 
 #pragma omp parallel num_threads(max_threads) default(none) shared(global_random_number_generator, input_star_file, first_particle, last_particle, apply_CTF, apply_shifts, \
                                                                    pixel_size, output_file, add_noise, wanted_SNR, apply_mask, mask_radius, my_progress, lines_to_process, image_counter, projection_3d, input_file, global_euler_search, number_of_projections_to_calculate, project_based_on_star, output_params) private(current_image, input_parameters, my_parameters, my_ctf, projection_image, final_image, variance)
@@ -297,21 +329,21 @@ bool Project3DApp::DoCalculation( ) {
 
             // fill in the parameters..
 
-            output_params.all_parameters[current_image].position_in_stack = current_image + 1;
-            output_params.all_parameters[current_image].image_is_active = 1;
-            output_params.all_parameters[current_image].psi           = my_parameters.ReturnPsiAngle();
-            output_params.all_parameters[current_image].theta         = my_parameters.ReturnThetaAngle();
-            output_params.all_parameters[current_image].phi           = my_parameters.ReturnPhiAngle();
-            output_params.all_parameters[current_image].x_shift       = 0.0f;
-            output_params.all_parameters[current_image].y_shift       = 0.0f;
-            output_params.all_parameters[current_image].defocus_1     = 0.0f;
-            output_params.all_parameters[current_image].defocus_2     = 0.0f;
-            output_params.all_parameters[current_image].defocus_angle = 0.0f;
-            output_params.all_parameters[current_image].phase_shift   = 0.0f;
-            output_params.all_parameters[current_image].occupancy     = 100.0f;
-            output_params.all_parameters[current_image].logp          = -100;
-            output_params.all_parameters[current_image].sigma = 10.0f;
-            output_params.all_parameters[current_image].score         = 10.0f;
+            output_params.all_parameters[current_image].position_in_stack                  = current_image + 1;
+            output_params.all_parameters[current_image].image_is_active                    = 1;
+            output_params.all_parameters[current_image].psi                                = my_parameters.ReturnPsiAngle( );
+            output_params.all_parameters[current_image].theta                              = my_parameters.ReturnThetaAngle( );
+            output_params.all_parameters[current_image].phi                                = my_parameters.ReturnPhiAngle( );
+            output_params.all_parameters[current_image].x_shift                            = 0.0f;
+            output_params.all_parameters[current_image].y_shift                            = 0.0f;
+            output_params.all_parameters[current_image].defocus_1                          = 0.0f;
+            output_params.all_parameters[current_image].defocus_2                          = 0.0f;
+            output_params.all_parameters[current_image].defocus_angle                      = 0.0f;
+            output_params.all_parameters[current_image].phase_shift                        = 0.0f;
+            output_params.all_parameters[current_image].occupancy                          = 100.0f;
+            output_params.all_parameters[current_image].logp                               = -100;
+            output_params.all_parameters[current_image].sigma                              = 10.0f;
+            output_params.all_parameters[current_image].score                              = 10.0f;
             output_params.all_parameters[current_image].score_change                       = 0.0f;
             output_params.all_parameters[current_image].pixel_size                         = pixel_size;
             output_params.all_parameters[current_image].microscope_voltage_kv              = 300.0f;

--- a/src/programs/project3d/project3d.cpp
+++ b/src/programs/project3d/project3d.cpp
@@ -18,6 +18,7 @@ void Project3DApp::DoInteractiveUserInput( ) {
     wxString input_star_filename;
     wxString input_reconstruction;
     wxString ouput_projection_stack;
+    wxString output_star_file;
     int      first_particle = 1;
     int      last_particle  = 0;
     float    pixel_size     = 1;
@@ -55,6 +56,7 @@ void Project3DApp::DoInteractiveUserInput( ) {
     }
     else {
         angular_step = my_input->GetFloatFromUser("Angular step for projection", "Angular step size for grid projection", "0.0", 0.1);
+        output_star_file = my_input->GetFilenameFromUser("Output Star File", "The star file containing angles for the projections", "output_angles.star", false);
         apply_CTF    = false;
         apply_shifts = false;
     }
@@ -85,13 +87,13 @@ void Project3DApp::DoInteractiveUserInput( ) {
     delete my_input;
 
     //	my_current_job.Reset(14);
-    my_current_job.ManualSetArguments("tttiifffftbbbbbfi", input_star_filename.ToUTF8( ).data( ),
+    my_current_job.ManualSetArguments("tttiifffftbbbbbfit", input_star_filename.ToUTF8( ).data( ),
                                       input_reconstruction.ToUTF8( ).data( ),
                                       ouput_projection_stack.ToUTF8( ).data( ),
                                       first_particle, last_particle,
                                       pixel_size, mask_radius, wanted_SNR, padding,
                                       my_symmetry.ToUTF8( ).data( ),
-                                      apply_CTF, apply_shifts, apply_mask, add_noise, project_based_on_star, angular_step, max_threads);
+                                      apply_CTF, apply_shifts, apply_mask, add_noise, project_based_on_star, angular_step, max_threads, output_star_file.ToUTF8().data());
 }
 
 // override the do calculation method which will be what is actually run..
@@ -121,11 +123,13 @@ bool Project3DApp::DoCalculation( ) {
     bool     project_based_on_star = my_current_job.arguments[14].ReturnBoolArgument( );
     float    angular_step          = my_current_job.arguments[15].ReturnFloatArgument( );
     int      max_threads           = my_current_job.arguments[16].ReturnIntegerArgument( );
+    wxString output_star_file     = my_current_job.arguments[17].ReturnStringArgument( );
 
     Image               projection_image;
     Image               final_image;
     ReconstructedVolume input_3d;
     Image               projection_3d;
+    cisTEMParameters output_params;
 
     int image_counter = 0;
     int number_of_projections_to_calculate;
@@ -225,13 +229,22 @@ bool Project3DApp::DoCalculation( ) {
     if ( project_based_on_star == true )
         number_of_projections_to_calculate = lines_to_process.GetCount( );
     else
+    {
         number_of_projections_to_calculate = global_euler_search.number_of_search_positions;
+
+        // setup paramters
+
+        output_params.parameters_to_write.SetActiveParameters(POSITION_IN_STACK | IMAGE_IS_ACTIVE | PSI | THETA | PHI | X_SHIFT | Y_SHIFT | DEFOCUS_1 | DEFOCUS_2 | DEFOCUS_ANGLE | PHASE_SHIFT | OCCUPANCY | LOGP | SIGMA | SCORE | PIXEL_SIZE | MICROSCOPE_VOLTAGE | MICROSCOPE_CS | AMPLITUDE_CONTRAST | BEAM_TILT_X | BEAM_TILT_Y | IMAGE_SHIFT_X | IMAGE_SHIFT_Y | ASSIGNED_SUBSET);
+        output_params.PreallocateMemoryAndBlank(number_of_projections_to_calculate);
+    }
 
     ProgressBar* my_progress = new ProgressBar(number_of_projections_to_calculate);
     projection_3d.CopyFrom(input_3d.density_map);
 
+
+
 #pragma omp parallel num_threads(max_threads) default(none) shared(global_random_number_generator, input_star_file, first_particle, last_particle, apply_CTF, apply_shifts, \
-                                                                   pixel_size, output_file, add_noise, wanted_SNR, apply_mask, mask_radius, my_progress, lines_to_process, image_counter, projection_3d, input_file, global_euler_search, number_of_projections_to_calculate, project_based_on_star) private(current_image, input_parameters, my_parameters, my_ctf, projection_image, final_image, variance)
+                                                                   pixel_size, output_file, add_noise, wanted_SNR, apply_mask, mask_radius, my_progress, lines_to_process, image_counter, projection_3d, input_file, global_euler_search, number_of_projections_to_calculate, project_based_on_star, output_params) private(current_image, input_parameters, my_parameters, my_ctf, projection_image, final_image, variance)
     {
 
         projection_image.Allocate(input_file.ReturnXSize( ), input_file.ReturnYSize( ), false);
@@ -274,16 +287,50 @@ bool Project3DApp::DoCalculation( ) {
                 final_image.CosineMask(mask_radius / input_parameters.pixel_size, 6.0);
 
 #pragma omp ordered
+
+            //write slice and parameters
+
             final_image.WriteSlice(&output_file, current_image + 1);
 
 #pragma omp atomic
             image_counter++;
+
+            // fill in the parameters..
+
+            output_params.all_parameters[current_image].position_in_stack = current_image + 1;
+            output_params.all_parameters[current_image].image_is_active = 1;
+            output_params.all_parameters[current_image].psi           = my_parameters.ReturnPsiAngle();
+            output_params.all_parameters[current_image].theta         = my_parameters.ReturnThetaAngle();
+            output_params.all_parameters[current_image].phi           = my_parameters.ReturnPhiAngle();
+            output_params.all_parameters[current_image].x_shift       = 0.0f;
+            output_params.all_parameters[current_image].y_shift       = 0.0f;
+            output_params.all_parameters[current_image].defocus_1     = 0.0f;
+            output_params.all_parameters[current_image].defocus_2     = 0.0f;
+            output_params.all_parameters[current_image].defocus_angle = 0.0f;
+            output_params.all_parameters[current_image].phase_shift   = 0.0f;
+            output_params.all_parameters[current_image].occupancy     = 100.0f;
+            output_params.all_parameters[current_image].logp          = -100;
+            output_params.all_parameters[current_image].sigma = 10.0f;
+            output_params.all_parameters[current_image].score         = 10.0f;
+            output_params.all_parameters[current_image].score_change                       = 0.0f;
+            output_params.all_parameters[current_image].pixel_size                         = pixel_size;
+            output_params.all_parameters[current_image].microscope_voltage_kv              = 300.0f;
+            output_params.all_parameters[current_image].microscope_spherical_aberration_mm = 2.7f;
+            output_params.all_parameters[current_image].amplitude_contrast                 = 0.07;
+            output_params.all_parameters[current_image].beam_tilt_x                        = 0.0f;
+            output_params.all_parameters[current_image].beam_tilt_y                        = 0.0f;
+            output_params.all_parameters[current_image].image_shift_x                      = 0.0f;
+            output_params.all_parameters[current_image].image_shift_y                      = 0.0f;
 
             if ( is_running_locally == true && ReturnThreadNumberOfCurrentThread( ) == 0 )
                 my_progress->Update(image_counter);
         }
     }
     // end omp
+
+    // write star file
+
+    output_params.WriteTocisTEMStarFile(output_star_file);
     delete my_progress;
 
     wxPrintf("\n\nProject3D: Normal termination\n\n");


### PR DESCRIPTION
# Description

This change from @timothygrant80 writes out .star parameters at the end of project3d. This is a useful addition in the case where parameters from a 3D projection are needed for subsequent data processing. For example, rotational alignment and subtraction of the projection from a stack.

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [x] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [x] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [x] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
