### PR TITLE
Enable compiling without experimental features

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -217,8 +217,10 @@ noinst_HEADERS = core/stopwatch.h \
                  programs/console_test/sine_128x128x1.cpp \
                  gui/icons/match_template_icon.cpp \
                  programs/refine3d/ProjectionComparisonObjects.h \
+                 core/pdb.h \
                  core/scattering_potential.h \
                  programs/cisTEM_display/display_gui.h
+                 
 
                  
 
@@ -229,7 +231,6 @@ noinst_HEADERS += 	gui/icons/experimental_icon.cpp \
                     gui/AtomicCoordinatesChooserDialog.h \
                     gui/AtomicCoordinatesImportDialog.h \
                     core/water.h \
-                    core/pdb.h \
                     programs/simulate/wave_function_propagator.h 
 
 endif      
@@ -432,13 +433,14 @@ libcore_a_SOURCES  = core/stopwatch.cpp \
                        core/ccl3d.cpp \
                        core/template_matching.cpp \
                        core/eer_file.cpp \
+                       core/pdb.cpp \
                        core/scattering_potential.cpp \
                        core/padded_coordinates.cpp
 
 
 
 if EXPERIMENTAL_AM
-libcore_a_SOURCES += core/water.cpp core/pdb.cpp
+libcore_a_SOURCES += core/water.cpp
 endif
 
 libcore_a_CXXFLAGS = $(WX_CPPFLAGS_BASE)

--- a/src/core/core_headers.h
+++ b/src/core/core_headers.h
@@ -182,6 +182,7 @@ class StackDump : public wxStackWalker // so we can give backtraces..
 #include "json/jsonreader.h"
 #include "json/jsonval.h"
 #include "ccl3d.h"
+#include "pdb.h"
 
 #ifdef EXPERIMENTAL
 #include "../../include/ieee-754-half/half.hpp"
@@ -191,7 +192,6 @@ class StackDump : public wxStackWalker // so we can give backtraces..
 #include "../../include/gemmi/gz.hpp"
 #include "../../include/gemmi/resinfo.hpp"
 #include "../../include/gemmi/calculate.hpp"
-#include "pdb.h"
 #include "water.h"
 #endif
 


### PR DESCRIPTION
# Description

These are very small changes that involve removing PDB class files from experimental, as this prevented compiling without experimental enabled.

Fixes #459

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [x] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [x] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [x] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
