### PR TITLE
Some spring cleaning

### DIFF
--- a/src/constants/constants.h
+++ b/src/constants/constants.h
@@ -4,6 +4,10 @@
 #include <array>
 #include <string_view>
 
+constexpr long OPEN_TO_READ   = 0;
+constexpr long OPEN_TO_WRITE  = 1;
+constexpr long OPEN_TO_APPEND = 2;
+
 // Numerical constants for frequently used values like pi, sqrt(2), etc.
 #include "cistem_numbers.h"
 

--- a/src/core/numeric_text_file.cpp
+++ b/src/core/numeric_text_file.cpp
@@ -1,18 +1,21 @@
 #include "core_headers.h"
 
+/**
+ * @brief Construct a new Numeric Text File:: Numeric Text File object
+ * Disallowed before Apr-2024
+ */
 NumericTextFile::NumericTextFile( ) {
-    MyPrintWithDetails("NumericTextfile has been declared with no filename.\n");
-    DEBUG_ABORT;
+    file_is_not_dev_null = false;
 }
 
+/**
+ * @brief Construct a new Numeric Text File:: Numeric Text File object and open the file
+ * 
+ * @param Filename may be /dev/null to avoid file operations (noop)
+ * @param wanted_access_type OPEN_TO_READ, OPEN_TO_WRITE, OPEN_TO_APPEND
+ * @param wanted_records_per_line expected to be equal for all lines, defaults to 1, ignored when reading and determined from file.
+ */
 NumericTextFile::NumericTextFile(wxString Filename, long wanted_access_type, long wanted_records_per_line) {
-    input_file_stream  = NULL;
-    input_text_stream  = NULL;
-    output_file_stream = NULL;
-    output_text_stream = NULL;
-
-    do_nothing = false;
-
     Open(Filename, wanted_access_type, wanted_records_per_line);
 }
 
@@ -20,40 +23,59 @@ NumericTextFile::~NumericTextFile( ) {
     Close( );
 }
 
+/**
+ * @brief Open a file for reading, writing, or appending
+ * 
+ * @param Filename may be /dev/null to avoid file operations (noop)
+ * @param wanted_access_type OPEN_TO_READ, OPEN_TO_WRITE, OPEN_TO_APPEND
+ * @param wanted_records_per_line expected to be equal for all lines, defaults to 1, ignored when reading and determined from file.
+ */
 void NumericTextFile::Open(wxString Filename, long wanted_access_type, long wanted_records_per_line) {
+    MyDebugAssertTrue(wanted_access_type == OPEN_TO_READ || wanted_access_type == OPEN_TO_WRITE || wanted_access_type == OPEN_TO_APPEND, "Invalid access type");
+
     access_type      = wanted_access_type;
     records_per_line = wanted_records_per_line;
     text_filename    = Filename;
 
-    do_nothing = StartsWithDevNull(text_filename.ToStdString( ));
+    file_is_not_dev_null = ! StartsWithDevNull(text_filename.ToStdString( ));
+    if ( file_is_not_dev_null ) {
 
-    if ( ! do_nothing ) {
-        if ( access_type == OPEN_TO_READ ) {
-            if ( input_file_stream != NULL ) {
-                if ( input_file_stream->GetFile( )->IsOpened( ) == true ) {
-                    MyPrintWithDetails("File already Open\n");
+        switch ( access_type ) {
+            case OPEN_TO_READ: {
+                if ( input_file_stream ) {
+                    if ( input_file_stream->GetFile( )->IsOpened( ) ) {
+                        MyPrintWithDetails("File already Open\n");
+                        DEBUG_ABORT;
+                    }
+                }
+                break;
+            }
+            case OPEN_TO_WRITE: {
+                if ( records_per_line <= 0 ) {
+                    MyPrintWithDetails("NumericTextFile asked to OPEN_TO_WRITE, but with erroneous records per line\n");
                     DEBUG_ABORT;
                 }
-            }
-        }
-        else if ( access_type == OPEN_TO_WRITE ) {
-            records_per_line = wanted_records_per_line;
 
-            if ( records_per_line <= 0 ) {
-                MyPrintWithDetails("NumericTextFile asked to OPEN_TO_WRITE, but with erroneous records per line\n");
+                if ( output_file_stream ) {
+                    if ( output_file_stream->GetFile( )->IsOpened( ) ) {
+                        MyPrintWithDetails("File already Open\n");
+                        DEBUG_ABORT;
+                    }
+                }
+                break;
+            }
+            case OPEN_TO_APPEND: {
+                // FIXME: I don't think that open to append is handled.
+                MyDebugAssertTrue(false, "OPEN_TO_APPEND not implemented");
+                records_per_line = wanted_records_per_line;
+                break;
+            }
+            default: {
+                // This should probably be a run-time assert
+                MyPrintWithDetails("Unknown access type!\n");
                 DEBUG_ABORT;
+                break;
             }
-
-            if ( output_file_stream != NULL ) {
-                if ( output_file_stream->GetFile( )->IsOpened( ) == true ) {
-                    MyPrintWithDetails("File already Open\n");
-                    DEBUG_ABORT;
-                }
-            }
-        }
-        else {
-            MyPrintWithDetails("Unknown access type!\n");
-            DEBUG_ABORT;
         }
 
         Init( );
@@ -61,43 +83,45 @@ void NumericTextFile::Open(wxString Filename, long wanted_access_type, long want
 }
 
 void NumericTextFile::Close( ) {
-    if ( input_text_stream != NULL )
+    if ( input_text_stream )
         delete input_text_stream;
-    if ( output_text_stream != NULL )
+    if ( output_text_stream )
         delete output_text_stream;
 
-    if ( output_file_stream != NULL ) {
-        if ( output_file_stream->GetFile( )->IsOpened( ) == true )
+    if ( output_file_stream ) {
+        if ( output_file_stream->GetFile( )->IsOpened( ) )
             output_file_stream->GetFile( )->Close( );
         delete output_file_stream;
     }
 
-    if ( input_file_stream != NULL ) {
-        if ( input_file_stream->GetFile( )->IsOpened( ) == true )
+    if ( input_file_stream ) {
+        if ( input_file_stream->GetFile( )->IsOpened( ) )
             input_file_stream->GetFile( )->Close( );
         delete input_file_stream;
     }
 
-    input_file_stream  = NULL;
-    input_text_stream  = NULL;
-    output_file_stream = NULL;
-    output_text_stream = NULL;
+    input_file_stream  = nullptr;
+    input_text_stream  = nullptr;
+    output_file_stream = nullptr;
+    output_text_stream = nullptr;
 }
 
+// private, only called form Open which has asserts there.
 void NumericTextFile::Init( ) {
-
-    if ( ! do_nothing ) {
+    if ( file_is_not_dev_null ) {
         if ( access_type == OPEN_TO_READ ) {
             wxString current_line;
             wxString token;
             double   temp_double;
             int      current_records_per_line;
-            int      old_records_per_line = -1;
+            // When reading, we ignore the records per line and get this info from the file.
+            records_per_line          = -1;
+            bool records_per_line_set = false;
 
             input_file_stream = new wxFileInputStream(text_filename);
             input_text_stream = new wxTextInputStream(*input_file_stream);
 
-            if ( input_file_stream->IsOk( ) == false ) {
+            if ( ! input_file_stream->IsOk( ) ) {
                 MyPrintWithDetails("Attempt to access %s for reading failed\n", text_filename);
                 DEBUG_ABORT;
             }
@@ -106,11 +130,11 @@ void NumericTextFile::Init( ) {
 
             number_of_lines = 0;
 
-            while ( input_file_stream->Eof( ) == false ) {
+            while ( ! input_file_stream->Eof( ) ) {
                 current_line = input_text_stream->ReadLine( );
                 current_line.Trim(false);
 
-                if ( current_line.StartsWith("#") != true && current_line.StartsWith("C") != true && current_line.Length( ) > 0 ) {
+                if ( ! LineIsACommentOrZeroLength(current_line) ) {
                     number_of_lines++;
                     wxStringTokenizer tokenizer(current_line);
 
@@ -119,38 +143,37 @@ void NumericTextFile::Init( ) {
                     while ( tokenizer.HasMoreTokens( ) ) {
                         token = tokenizer.GetNextToken( );
 
-                        if ( token.ToDouble(&temp_double) == false ) {
-                            MyPrintWithDetails("Failed on the following record : %s\n", token);
-                            DEBUG_ABORT;
+                        if ( token.ToDouble(&temp_double) ) {
+                            current_records_per_line++;
                         }
                         else {
-                            current_records_per_line++;
+                            MyPrintWithDetails("Failed on the following record : %s\n", token);
+                            DEBUG_ABORT;
                         }
                     }
 
                     // we want to check records_per_line for consistency..
 
-                    if ( old_records_per_line != -1 ) {
-                        if ( old_records_per_line != current_records_per_line ) {
+                    if ( records_per_line_set ) {
+                        if ( records_per_line != current_records_per_line ) {
                             MyPrintWithDetails("Different records per line found");
                             DEBUG_ABORT;
                         }
                     }
-
-                    old_records_per_line = current_records_per_line;
+                    else {
+                        records_per_line     = current_records_per_line;
+                        records_per_line_set = true;
+                    }
                 }
             }
 
-            records_per_line = current_records_per_line;
-
             // rewind the file..
-
             Rewind( );
         }
         else if ( access_type == OPEN_TO_WRITE ) {
             // check if the file exists..
 
-            if ( DoesFileExist(text_filename) == true ) {
+            if ( DoesFileExist(text_filename) ) {
                 if ( wxRemoveFile(text_filename) == false ) {
                     MyDebugPrintWithDetails("Cannot remove already existing text file");
                 }
@@ -159,11 +182,20 @@ void NumericTextFile::Init( ) {
             output_file_stream = new wxFileOutputStream(text_filename);
             output_text_stream = new wxTextOutputStream(*output_file_stream);
         }
+        else {
+            MyPrintWithDetails("Unknown access type!\n");
+            DEBUG_ABORT;
+        }
     }
 }
 
+/**
+ * @brief Reset the file pointer to the beginning of the file
+ * 
+ */
 void NumericTextFile::Rewind( ) {
-    if ( ! do_nothing ) {
+    if ( file_is_not_dev_null ) {
+        MyDebugAssertTrue(access_type == OPEN_TO_READ ? (input_file_stream && input_text_stream) : output_file_stream != nullptr, "Rewind called on a file that is not open");
         if ( access_type == OPEN_TO_READ ) {
             delete input_file_stream;
             delete input_text_stream;
@@ -177,7 +209,7 @@ void NumericTextFile::Rewind( ) {
 }
 
 void NumericTextFile::Flush( ) {
-    if ( ! do_nothing ) {
+    if ( file_is_not_dev_null ) {
         if ( access_type == OPEN_TO_READ )
             input_file_stream->GetFile( )->Flush( );
         else
@@ -186,7 +218,7 @@ void NumericTextFile::Flush( ) {
 }
 
 void NumericTextFile::ReadLine(float* data_array) {
-    if ( ! do_nothing ) {
+    if ( file_is_not_dev_null ) {
         if ( access_type != OPEN_TO_READ ) {
             MyPrintWithDetails("Attempt to read from %s however access type is not READ\n", text_filename);
             DEBUG_ABORT;
@@ -196,11 +228,11 @@ void NumericTextFile::ReadLine(float* data_array) {
         wxString token;
         double   temp_double;
 
-        while ( input_file_stream->Eof( ) == false ) {
+        while ( ! input_file_stream->Eof( ) ) {
             current_line = input_text_stream->ReadLine( );
             current_line.Trim(false);
 
-            if ( current_line.StartsWith("C") == false && current_line.StartsWith("#") == false && current_line.Length( ) != 0 )
+            if ( ! LineIsACommentOrZeroLength(current_line) )
                 break;
         }
 
@@ -220,16 +252,26 @@ void NumericTextFile::ReadLine(float* data_array) {
     }
 }
 
-void NumericTextFile::WriteLine(float* data_array) {
-    if ( ! do_nothing ) {
+template <bool flag = false>
+inline void static_WriteLine_type_not_allowed( ) { static_assert(flag, "no NumericTextFile::WriteLine is only valid for float and double type!"); }
+
+template <typename T>
+void NumericTextFile::WriteLine(T* data_array) {
+
+    if ( file_is_not_dev_null ) {
         if ( access_type != OPEN_TO_WRITE ) {
             MyPrintWithDetails("Attempt to read from %s however access type is not WRITE\n", text_filename);
             DEBUG_ABORT;
         }
 
         for ( int counter = 0; counter < records_per_line; counter++ ) {
-            //		output_text_stream->WriteDouble(data_array[counter]);
-            output_text_stream->WriteString(wxString::Format("%14.5f", data_array[counter]));
+            if constexpr ( std::is_same_v<T, float> )
+                output_text_stream->WriteString(wxString::Format("%14.5f", data_array[counter]));
+            else if constexpr ( std::is_same_v<T, double> )
+                output_text_stream->WriteDouble(data_array[counter]);
+            else
+                static_WriteLine_type_not_allowed( );
+
             if ( counter != records_per_line - 1 )
                 output_text_stream->WriteString(" ");
         }
@@ -238,25 +280,11 @@ void NumericTextFile::WriteLine(float* data_array) {
     }
 }
 
-void NumericTextFile::WriteLine(double* data_array) {
-    if ( ! do_nothing ) {
-        if ( access_type != OPEN_TO_WRITE ) {
-            MyPrintWithDetails("Attempt to read from %s however access type is not WRITE\n", text_filename);
-            DEBUG_ABORT;
-        }
-
-        for ( int counter = 0; counter < records_per_line; counter++ ) {
-            output_text_stream->WriteDouble(data_array[counter]);
-            if ( counter != records_per_line - 1 )
-                output_text_stream->WriteString(" ");
-        }
-
-        output_text_stream->WriteString("\n");
-    }
-}
+template void NumericTextFile::WriteLine<float>(float* data_array);
+template void NumericTextFile::WriteLine<double>(double* data_array);
 
 void NumericTextFile::WriteCommentLine(const char* format, ...) {
-    if ( ! do_nothing ) {
+    if ( file_is_not_dev_null ) {
         va_list args;
         va_start(args, format);
 
@@ -279,8 +307,4 @@ void NumericTextFile::WriteCommentLine(const char* format, ...) {
 
         va_end(args);
     }
-}
-
-wxString NumericTextFile::ReturnFilename( ) {
-    return text_filename;
 }

--- a/src/core/numeric_text_file.h
+++ b/src/core/numeric_text_file.h
@@ -1,23 +1,36 @@
-#define OPEN_TO_READ 0
-#define OPEN_TO_WRITE 1
-#define OPEN_TO_APPEND 2
+#ifndef __SRC_CORE_NUMERIC_TEXT_FILE_H__
+#define __SRC_CORE_NUMERIC_TEXT_FILE_H__
+
+#include "../constants/constants.h"
 
 class NumericTextFile {
 
-  private:
-    void                Init( );
+    long access_type;
+
     wxString            text_filename;
-    long                access_type;
-    wxFileInputStream*  input_file_stream;
-    wxTextInputStream*  input_text_stream;
-    wxFileOutputStream* output_file_stream;
-    wxTextOutputStream* output_text_stream;
+    wxFileInputStream*  input_file_stream{ };
+    wxTextInputStream*  input_text_stream{ };
+    wxFileOutputStream* output_file_stream{ };
+    wxTextOutputStream* output_text_stream{ };
+    bool                default_constructed{ };
+    // In special cases (e.g. if the filename is /dev/null), we don't do anything
+    bool file_is_not_dev_null{ };
+    void Init( );
+
+    inline bool LineIsACommentOrZeroLength(const wxString& current_line) const {
+        return (current_line.StartsWith("#") || current_line.StartsWith("C") || current_line.Length( ) == 0);
+    }
 
   public:
-    // Constructors
     NumericTextFile( );
     NumericTextFile(wxString Filename, long wanted_access_type, long wanted_records_per_line = 1);
     ~NumericTextFile( );
+
+    // We don't want to allow copying or moving of this class
+    NumericTextFile(const NumericTextFile&)            = delete;
+    NumericTextFile& operator=(const NumericTextFile&) = delete;
+    NumericTextFile(NumericTextFile&&)                 = delete;
+    NumericTextFile& operator=(NumericTextFile&&)      = delete;
 
     // data
 
@@ -26,17 +39,19 @@ class NumericTextFile {
 
     // Methods
 
-    void     Open(wxString Filename, long wanted_access_type, long wanted_records_per_line = 1);
-    void     Close( );
-    void     Rewind( );
-    void     Flush( );
-    wxString ReturnFilename( );
+    void Open(wxString Filename, long wanted_access_type, long wanted_records_per_line = 1);
+    void Close( );
+    void Rewind( );
+    void Flush( );
+
+    wxString ReturnFilename( ) { return text_filename; }
 
     void ReadLine(float* data_array);
-    void WriteLine(float* data_array);
-    void WriteLine(double* data_array);
-    void WriteCommentLine(const char* format, ...);
 
-    // In special cases (e.g. if the filename is /dev/null), we don't do anything
-    bool do_nothing;
+    template <typename T>
+    void WriteLine(T* data_array);
+
+    void WriteCommentLine(const char* format, ...);
 };
+
+#endif // __SRC_CORE_NUMERIC_TEXT_FILE_H__

--- a/src/core/pdb.h
+++ b/src/core/pdb.h
@@ -1,6 +1,6 @@
-#define OPEN_TO_READ 0
-#define OPEN_TO_WRITE 1
-#define OPEN_TO_APPEND 2
+#ifndef _SRC_CORE_PDB_H_
+#define _SRC_CORE_PDB_H_
+
 #define MAX_NUMBER_OF_TIMESTEPS 2000
 
 #define MAX_NUMBER_OF_NOISE_PARTICLES 6
@@ -251,3 +251,5 @@ class PDB {
         return isAcidicOxygen;
     }
 };
+
+#endif // _SRC_CORE_PDB_H_

--- a/src/programs/console_test/console_test.cpp
+++ b/src/programs/console_test/console_test.cpp
@@ -1201,129 +1201,120 @@ void MyTestApp::TestNumericTextFiles( ) {
     // AddImage
     BeginTest("NumericTextFile::Init");
 
+    for ( int with_default_constructor = 0; with_default_constructor < 2; with_default_constructor++ ) {
+        if ( with_default_constructor > 0 ) {
+            NumericTextFile test_file;
+            test_file.Open(numeric_text_filename, OPEN_TO_READ);
+            if ( test_file.number_of_lines != 4 )
+                FailTest;
+            if ( test_file.records_per_line != 5 )
+                FailTest;
+        }
+        else {
+            NumericTextFile test_file(numeric_text_filename, OPEN_TO_READ);
+            if ( test_file.number_of_lines != 4 )
+                FailTest;
+            if ( test_file.records_per_line != 5 )
+                FailTest;
+        }
+    }
+    EndTest( );
+
     NumericTextFile test_file(numeric_text_filename, OPEN_TO_READ);
 
-    if ( test_file.number_of_lines != 4 )
-        FailTest;
-    if ( test_file.records_per_line != 5 )
-        FailTest;
-
-    EndTest( );
-
     BeginTest("NumericTextFile::ReadLine");
-    float temp_float[5];
+    std::array<float, 5>                temp_float;
+    std::array<double, 5>               temp_double;
+    std::array<std::array<float, 5>, 4> line_values;
+    line_values[0] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    line_values[1] = {6.0f, 7.1f, 8.3f, 9.4f, 10.5f};
+    line_values[2] = {11.2f, 12.7f, 13.2f, 14.1f, 15.8f};
+    line_values[3] = {16.1245f, 17.81003f, 18.5467f, 19.7621f, 20.11111f};
 
-    test_file.ReadLine(temp_float);
-
-    if ( int(temp_float[0]) != 1 )
-        FailTest;
-    if ( int(temp_float[1]) != 2 )
-        FailTest;
-    if ( int(temp_float[2]) != 3 )
-        FailTest;
-    if ( int(temp_float[3]) != 4 )
-        FailTest;
-    if ( int(temp_float[4]) != 5 )
-        FailTest;
-
-    test_file.ReadLine(temp_float);
-
-    if ( FloatsAreAlmostTheSame(temp_float[0], 6.0) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[1], 7.1) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[2], 8.3) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[3], 9.4) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[4], 10.5) == false )
-        FailTest;
-
-    test_file.ReadLine(temp_float);
-
-    if ( FloatsAreAlmostTheSame(temp_float[0], 11.2) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[1], 12.7) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[2], 13.2) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[3], 14.1) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[4], 15.8) == false )
-        FailTest;
-
-    test_file.ReadLine(temp_float);
-
-    if ( FloatsAreAlmostTheSame(temp_float[0], 16.1245) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[1], 17.81003) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[2], 18.5467) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[3], 19.7621) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[4], 20.11111) == false )
-        FailTest;
+    for ( int line = 0; line < line_values.size( ); line++ ) {
+        test_file.ReadLine(temp_float.data( ));
+        for ( int i = 0; i < line_values[line].size( ); i++ ) {
+            if ( FloatsAreAlmostTheSame(temp_float[i], line_values[line][i]) == false )
+                FailTest;
+        }
+    }
 
     EndTest( );
 
-    BeginTest("NumericTextFile::WriteLine");
+    BeginTest("NumericTextFile::WriteLine float");
 
     wxString        output_filename = temp_directory + "/number_out.num";
     NumericTextFile output_test_file(output_filename, OPEN_TO_WRITE, 5);
 
-    temp_float[0] = 0.1;
-    temp_float[1] = 0.2;
-    temp_float[2] = 0.3;
-    temp_float[3] = 0.4;
-    temp_float[4] = 0.5;
-
+    for ( int i = 0; i < line_values[0].size( ); i++ ) {
+        temp_float[i] = line_values[0][i];
+    }
+    output_test_file.WriteLine(temp_float.data( ));
     output_test_file.WriteCommentLine("This is a comment line %i", 5);
-    output_test_file.WriteLine(temp_float);
-    output_test_file.WriteCommentLine("Another comment = %s", "booooo!");
-    temp_float[0] = 0.67;
-    temp_float[1] = 0.78;
-    temp_float[2] = 0.89;
-    temp_float[3] = 0.91;
-    temp_float[4] = 1.02;
 
-    output_test_file.WriteLine(temp_float);
+    for ( int i = 0; i < line_values[1].size( ); i++ ) {
+        temp_float[i] = line_values[1][i];
+    }
+
+    output_test_file.WriteLine(temp_float.data( ));
+    output_test_file.WriteCommentLine("Another comment = %s", "booooo!");
+
     output_test_file.Flush( );
 
-    test_file.Close( );
-    test_file.Open(output_filename, OPEN_TO_READ);
-
-    if ( test_file.number_of_lines != 2 )
+    output_test_file.Close( );
+    output_test_file.Open(output_filename, OPEN_TO_READ);
+    // We only expect non-comment lines to be counted.
+    if ( output_test_file.number_of_lines != 2 )
         FailTest;
-    if ( test_file.records_per_line != 5 )
-        FailTest;
-
-    test_file.ReadLine(temp_float);
-
-    if ( FloatsAreAlmostTheSame(temp_float[0], 0.1) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[1], 0.2) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[2], 0.3) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[3], 0.4) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[4], 0.5) == false )
+    if ( output_test_file.records_per_line != 5 )
         FailTest;
 
-    test_file.ReadLine(temp_float);
+    for ( int line = 0; line < 2; line++ ) {
+        output_test_file.ReadLine(temp_float.data( ));
+        for ( int i = 0; i < line_values[line].size( ); i++ ) {
+            if ( FloatsAreAlmostTheSame(temp_float[i], line_values[line][i]) == false )
+                FailTest;
+        }
+    }
+    output_test_file.Close( );
+    EndTest( );
 
-    if ( FloatsAreAlmostTheSame(temp_float[0], 0.67) == false )
+    BeginTest("NumericTextFile::WriteLine double");
+
+    output_filename = temp_directory + "/number_out.num";
+    output_test_file.Open(output_filename, OPEN_TO_WRITE, 5);
+
+    for ( int i = 0; i < line_values[0].size( ); i++ ) {
+        temp_double[i] = line_values[0][i];
+    }
+    output_test_file.WriteLine(temp_double.data( ));
+    output_test_file.WriteCommentLine("This is a comment line %i", 5);
+
+    for ( int i = 0; i < line_values[1].size( ); i++ ) {
+        temp_double[i] = line_values[1][i];
+    }
+
+    output_test_file.WriteLine(temp_double.data( ));
+    output_test_file.WriteCommentLine("Another comment = %s", "booooo!");
+
+    output_test_file.Flush( );
+
+    output_test_file.Close( );
+    output_test_file.Open(output_filename, OPEN_TO_READ);
+
+    if ( output_test_file.number_of_lines != 2 )
         FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[1], 0.78) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[2], 0.89) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[3], 0.91) == false )
-        FailTest;
-    if ( FloatsAreAlmostTheSame(temp_float[4], 1.02) == false )
+    if ( output_test_file.records_per_line != 5 )
         FailTest;
 
+    for ( int line = 0; line < 2; line++ ) {
+        output_test_file.ReadLine(temp_float.data( ));
+        for ( int i = 0; i < line_values[line].size( ); i++ ) {
+            if ( FloatsAreAlmostTheSame(temp_float[i], line_values[line][i]) == false )
+                FailTest;
+        }
+    }
+    output_test_file.Close( );
     EndTest( );
 }
 
@@ -1617,7 +1608,6 @@ void MyTestApp::TestScalingAndSizingFunctions( ) {
     test_image.ReadSlice(&input_file, 1);
     test_image.ClipInto(&clipped_image, 0);
 
-    //wxPrintf("value = %f\n", clipped_image.ReturnRealPixelValue(119,119));
     if ( FloatsAreAlmostTheSame(clipped_image.ReturnRealPixelFromPhysicalCoord(40, 40, 0), -0.340068) == false )
         FailTest;
     if ( FloatsAreAlmostTheSame(clipped_image.ReturnRealPixelFromPhysicalCoord(80, 80, 0), 1.819805) == false )
@@ -1667,7 +1657,6 @@ void MyTestApp::TestScalingAndSizingFunctions( ) {
         FailTest;
 
     test_pixel = clipped_image.ReturnComplexPixelFromLogicalCoord(5, 5, 0, -100.0f + I * 0.0f);
-    //wxPrintf("real = %f, image = %f\n", creal(test_pixel),cimag(test_pixel));
     if ( FloatsAreAlmostTheSame(real(test_pixel), 0.075896) == false || FloatsAreAlmostTheSame(imag(test_pixel), 0.045677) == false )
         FailTest;
 
@@ -1694,7 +1683,6 @@ void MyTestApp::TestScalingAndSizingFunctions( ) {
         FailTest;
 
     test_pixel = clipped_image.ReturnComplexPixelFromLogicalCoord(5, 5, 0, -100.0f + I * 0.0f);
-    //wxPrintf("real = %f, image = %f\n", creal(test_pixel),cimag(test_pixel));
     if ( FloatsAreAlmostTheSame(real(test_pixel), 0.075896) == false || FloatsAreAlmostTheSame(imag(test_pixel), 0.045677) == false )
         FailTest;
 
@@ -1757,13 +1745,10 @@ void MyTestApp::TestScalingAndSizingFunctions( ) {
         FailTest;
 
     test_pixel = test_image.ReturnComplexPixelFromLogicalCoord(5, 5, 0, -100.0f + I * 0.0f);
-    //wxPrintf("real = %f, image = %f\n", creal(test_pixel),cimag(test_pixel));
     if ( FloatsAreAlmostTheSame(real(test_pixel), 0.075896) == false || FloatsAreAlmostTheSame(imag(test_pixel), 0.045677) == false )
         FailTest;
 
     EndTest( );
-
-    //wxPrintf ("real = %f, imag = %f", creal(test_pixel), cimag(test_pixel), 0.0);
 }
 
 void MyTestApp::TestMRCFunctions( ) {


### PR DESCRIPTION
Remove footguns from numeric text file, expand tests and remove duplicated defines and replace with constepxr.

# Description

- Already working on something that requires NumericTextFile, so I decided to clean up a few cases where error handling was incomplete or not present.
- Renamed and refactored a few variables for clarity
- Enabled default construction without initialization
- Removed duplicated code (replaced with template)
- Add doxygen comments to primary functions
- Remove duplicate defines for OPEN_TO_WRITE/READ/APPEND and moved to constexpr so the compiler knows and can check types.

NOTE: the behavior of the constructor/OPEN argument "wanted_records_per_line" is a bit misleading as it seems to only be valid when OPEN_TO_WRITE

NOTE: OPEN_TO_APPEND is not implemented - added a debug assert

For expand symmetry stack and par, just removed nested comments to clear a compiler warning and also to reduce clutter when doing repo wide regex.

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [D] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [D] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [D] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [X] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
