### PR TITLE
Picking results zoom

### DIFF
--- a/src/gui/DisplayPanel.cpp
+++ b/src/gui/DisplayPanel.cpp
@@ -1474,15 +1474,18 @@ void DisplayNotebookPanel::UpdateImageStatusInfo(int x_pos, int y_pos) {
     double current_resolution;
 
     if ( single_image ) {
+        // Set the x,y positions
         int current_x_pos = single_image_x + (x_pos / actual_scale_factor); // - 1;
         int current_y_pos = single_image_y + (y_pos / actual_scale_factor); // - 1;
 
+        // Use wxWidgets 0,0 in upper left corner
         current_y_pos = ReturnImageYSize( ) - 1 - current_y_pos;
 
         int current_image = current_location;
 
         int current_radius = sqrtf(pow(current_x_pos - (ReturnImageXSize( ) / 2), 2) + pow(current_y_pos - (ReturnImageYSize( ) / 2), 2));
 
+        // This if-else does the same thing...should it be ReturnImageYSize in the else?
         if ( ReturnImageXSize( ) > ReturnImageYSize( ) )
             current_resolution = (pixel_size * ReturnImageXSize( )) / current_radius;
         else
@@ -2374,6 +2377,11 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
                             panel_image->Resize(wxSize(ReturnImageXSize( ), ReturnImageYSize( )), wxPoint(0, 0));
                         }
 
+                        // REMOVE COMMENT:
+                        // THIS is pointer to the wxImage's data; this is where we're loading in the information
+                        // So, I can just emulate the process in the ConvertImageToBitmap function
+                        // What this means is that you build the full bitmap, and then crop it down to the region that fits
+                        // within the boundaries of the panel -- makes sense given current behavior of picking results panel
                         unsigned char* image_data = panel_image->GetData( );
 
                         // are we locally scaling?
@@ -2572,9 +2580,10 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
                         // DEBUG:
                         wxPrintf("Before if statements: cut_x_size == %li, cut_y_size == %li\n", cut_x_size, cut_y_size);
                         int quick_sum = int(single_image_x * actual_scale_factor + window_x_size);
-                        wxPrintf("Comparison values: single_image_x == %i * actual_scale_factor == %d + window_x_size == %i = %i", single_image_x, actual_scale_factor, window_x_size, quick_sum);
+                        wxPrintf("Comparison values: single_image_x == %i * actual_scale_factor == %f + window_x_size == %i = %i\n", single_image_x, actual_scale_factor, window_x_size, quick_sum);
+                        wxPrintf("MRC size: x: %i, y: %i\n", panel_image->GetWidth( ), panel_image->GetHeight( ));
                         quick_sum = int(single_image_y * actual_scale_factor + window_y_size);
-                        wxPrintf("Comparison values: single_image_y == %i * actual_scale_factor == %d + window_y_size == %i = %i", single_image_y, actual_scale_factor, window_y_size, quick_sum);
+                        wxPrintf("Comparison values: single_image_y == %i * actual_scale_factor == %f + window_y_size == %i = %i\n", single_image_y, actual_scale_factor, window_y_size, quick_sum);
                         if ( single_image_x * actual_scale_factor + window_x_size > panel_image->GetWidth( ) )
                             cut_x_size = panel_image->GetWidth( ) - single_image_x * actual_scale_factor;
                         if ( single_image_y * actual_scale_factor + window_y_size > panel_image->GetHeight( ) )

--- a/src/gui/DisplayPanel.cpp
+++ b/src/gui/DisplayPanel.cpp
@@ -2569,12 +2569,18 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
 
                         // cut out the appropriate section taking the scaling factor into account.
                         // prevent cutting outside the size of the image..
-
+                        // DEBUG:
+                        wxPrintf("Before if statements: cut_x_size == %li, cut_y_size == %li\n", cut_x_size, cut_y_size);
+                        int quick_sum = int(single_image_x * actual_scale_factor + window_x_size);
+                        wxPrintf("Comparison values: single_image_x == %i * actual_scale_factor == %d + window_x_size == %i = %i", single_image_x, actual_scale_factor, window_x_size, quick_sum);
+                        quick_sum = int(single_image_y * actual_scale_factor + window_y_size);
+                        wxPrintf("Comparison values: single_image_y == %i * actual_scale_factor == %d + window_y_size == %i = %i", single_image_y, actual_scale_factor, window_y_size, quick_sum);
                         if ( single_image_x * actual_scale_factor + window_x_size > panel_image->GetWidth( ) )
                             cut_x_size = panel_image->GetWidth( ) - single_image_x * actual_scale_factor;
                         if ( single_image_y * actual_scale_factor + window_y_size > panel_image->GetHeight( ) )
                             cut_y_size = panel_image->GetHeight( ) - single_image_y * actual_scale_factor;
-
+                        // DEBUG:
+                        wxPrintf("After if statements: cut_x_size == %li, cut_y_size == %li\n", cut_x_size, cut_y_size);
                         FrameImage = panel_image->GetSubImage(wxRect(single_image_x * actual_scale_factor, single_image_y * actual_scale_factor, cut_x_size, cut_y_size));
                     }
                     else {

--- a/src/gui/DisplayPanel.cpp
+++ b/src/gui/DisplayPanel.cpp
@@ -2377,11 +2377,6 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
                             panel_image->Resize(wxSize(ReturnImageXSize( ), ReturnImageYSize( )), wxPoint(0, 0));
                         }
 
-                        // REMOVE COMMENT:
-                        // THIS is pointer to the wxImage's data; this is where we're loading in the information
-                        // So, I can just emulate the process in the ConvertImageToBitmap function
-                        // What this means is that you build the full bitmap, and then crop it down to the region that fits
-                        // within the boundaries of the panel -- makes sense given current behavior of picking results panel
                         unsigned char* image_data = panel_image->GetData( );
 
                         // are we locally scaling?
@@ -2577,19 +2572,12 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
 
                         // cut out the appropriate section taking the scaling factor into account.
                         // prevent cutting outside the size of the image..
-                        // DEBUG:
-                        wxPrintf("Before if statements: cut_x_size == %li, cut_y_size == %li\n", cut_x_size, cut_y_size);
                         int quick_sum = int(single_image_x * actual_scale_factor + window_x_size);
-                        wxPrintf("Comparison values: single_image_x == %i * actual_scale_factor == %f + window_x_size == %i = %i\n", single_image_x, actual_scale_factor, window_x_size, quick_sum);
-                        wxPrintf("MRC size: x: %i, y: %i\n", panel_image->GetWidth( ), panel_image->GetHeight( ));
-                        quick_sum = int(single_image_y * actual_scale_factor + window_y_size);
-                        wxPrintf("Comparison values: single_image_y == %i * actual_scale_factor == %f + window_y_size == %i = %i\n", single_image_y, actual_scale_factor, window_y_size, quick_sum);
+                        quick_sum     = int(single_image_y * actual_scale_factor + window_y_size);
                         if ( single_image_x * actual_scale_factor + window_x_size > panel_image->GetWidth( ) )
                             cut_x_size = panel_image->GetWidth( ) - single_image_x * actual_scale_factor;
                         if ( single_image_y * actual_scale_factor + window_y_size > panel_image->GetHeight( ) )
                             cut_y_size = panel_image->GetHeight( ) - single_image_y * actual_scale_factor;
-                        // DEBUG:
-                        wxPrintf("After if statements: cut_x_size == %li, cut_y_size == %li\n", cut_x_size, cut_y_size);
                         FrameImage = panel_image->GetSubImage(wxRect(single_image_x * actual_scale_factor, single_image_y * actual_scale_factor, cut_x_size, cut_y_size));
                     }
                     else {

--- a/src/gui/DisplayPanel.cpp
+++ b/src/gui/DisplayPanel.cpp
@@ -2572,8 +2572,6 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
 
                         // cut out the appropriate section taking the scaling factor into account.
                         // prevent cutting outside the size of the image..
-                        int quick_sum = int(single_image_x * actual_scale_factor + window_x_size);
-                        quick_sum     = int(single_image_y * actual_scale_factor + window_y_size);
                         if ( single_image_x * actual_scale_factor + window_x_size > panel_image->GetWidth( ) )
                             cut_x_size = panel_image->GetWidth( ) - single_image_x * actual_scale_factor;
                         if ( single_image_y * actual_scale_factor + window_y_size > panel_image->GetHeight( ) )

--- a/src/gui/PickingBitmapPanel.cpp
+++ b/src/gui/PickingBitmapPanel.cpp
@@ -87,6 +87,8 @@ PickingBitmapPanel::~PickingBitmapPanel( ) {
     Unbind(wxEVT_SIZE, &PickingBitmapPanel::OnSize, this);
     Unbind(wxEVT_LEFT_DOWN, &PickingBitmapPanel::OnLeftDown, this);
     Unbind(wxEVT_LEFT_UP, &PickingBitmapPanel::OnLeftUp, this);
+    Unbind(wxEVT_RIGHT_DOWN, &PickingBitmapPanel::OnRightDown, this);
+    Unbind(wxEVT_RIGHT_UP, &PickingBitmapPanel::OnRightUp, this);
     Unbind(wxEVT_MOTION, &PickingBitmapPanel::OnMotion, this);
 }
 
@@ -426,7 +428,6 @@ void PickingBitmapPanel::OnPaint(wxPaintEvent& evt) {
                 dc.DrawText(scalebar_label, bitmap_x_offset + scalebar_x_start + scalebar_length / 2 - scalebar_label_width / 2, bitmap_y_offset + scalebar_y_pos - scalebar_label_height - scalebar_thickness / 8);
             }
 
-            // FIXME: why isn't the selection rectangle appearing?
             // Draw selection retangle
             if ( draw_selection_rectangle ) {
                 dc.SetPen(wxPen(wxColor(255, 0, 0), pen_thickness * 2, wxPENSTYLE_LONG_DASH));
@@ -661,6 +662,8 @@ void PickingBitmapPanel::OnMotion(wxMouseEvent& event) {
     if ( draw_selection_rectangle ) {
         selection_rectangle_current_x = x_pos;
         selection_rectangle_current_y = y_pos;
+        Refresh( );
+        Update( );
     }
     else if ( event.LeftIsDown( ) == true && event.ShiftDown( ) ) // is the left button and shift down
     {

--- a/src/gui/PickingBitmapPanel.h
+++ b/src/gui/PickingBitmapPanel.h
@@ -127,7 +127,6 @@ class PickingBitmapPanel : public wxPanel {
     float clicked_point_x_in_angstroms;
     float clicked_point_y_in_angstroms;
 
-    //
     int bitmap_x_offset;
     int bitmap_y_offset;
     int bitmap_width;

--- a/src/gui/PickingBitmapPanel.h
+++ b/src/gui/PickingBitmapPanel.h
@@ -116,8 +116,8 @@ class PickingBitmapPanel : public wxPanel {
     int   selection_rectangle_current_y;
     long  old_mouse_x;
     long  old_mouse_y;
-    long  image_in_bitmap_x;
-    long  image_in_bitmap_y;
+    long  image_starting_x_coord;
+    long  image_starting_y_coord;
     float selection_rectangle_start_x_in_angstroms;
     float selection_rectangle_start_y_in_angstroms;
     float selection_rectangle_finish_x_in_angstroms;

--- a/src/gui/PickingBitmapPanel.h
+++ b/src/gui/PickingBitmapPanel.h
@@ -1,6 +1,7 @@
 #ifndef __PICKING_BITMAP_PANEL_H__
 #define __PICKING_BITMAP_PANEL_H__
 
+#include <wx/popupwin.h>
 #include <wx/panel.h>
 #include <vector>
 #include <functional>
@@ -24,10 +25,13 @@ struct particle_coordinate
 
 WX_DECLARE_OBJARRAY(ArrayOfParticlePositionAssets, ArrayOfCoordinatesHistory);
 
+class PickingBitmapPanelPopup;
+
 class PickingBitmapPanel : public wxPanel {
   public:
-    wxBitmap PanelBitmap; // buffer for the panel size
-    wxString panel_text;
+    wxBitmap                 PanelBitmap; // buffer for the panel size
+    wxString                 panel_text;
+    PickingBitmapPanelPopup* popup;
 
     ArrayOfParticlePositionAssets particle_coordinates_in_angstroms;
 
@@ -63,6 +67,8 @@ class PickingBitmapPanel : public wxPanel {
     // Mouse event handles
     void     OnLeftDown(wxMouseEvent& event);
     void     OnLeftUp(wxMouseEvent& event);
+    void     OnRightDown(wxMouseEvent& event);
+    void     OnRightUp(wxMouseEvent& event);
     void     OnMotion(wxMouseEvent& event);
     wxCursor CreatePaintCursor( );
 
@@ -76,6 +82,7 @@ class PickingBitmapPanel : public wxPanel {
     bool  should_wiener_filter;
     bool  draw_scale_bar;
     bool  allow_editing_of_coordinates;
+    bool  popup_exists;
 
     float low_res_filter_value;
     float high_res_filter_value;
@@ -118,6 +125,22 @@ class PickingBitmapPanel : public wxPanel {
     int bitmap_y_offset;
     int bitmap_width;
     int bitmap_height;
+};
+
+class PickingBitmapPanelPopup : public wxPopupWindow {
+    PickingBitmapPanel* parent_picking_bitmap_panel;
+
+  public:
+    PickingBitmapPanelPopup(wxWindow* parent, int flags = wxBORDER_NONE);
+
+    void OnPaint(wxPaintEvent& event);
+    void OnEraseBackground(wxEraseEvent& event);
+
+    int x_pos;
+    int y_pos;
+
+    float current_low_grey_value;
+    float current_high_grey_value;
 };
 
 #endif

--- a/src/gui/PickingBitmapPanel.h
+++ b/src/gui/PickingBitmapPanel.h
@@ -85,7 +85,7 @@ class PickingBitmapPanel : public wxPanel {
     bool   allow_editing_of_coordinates;
     bool   popup_exists;
     bool   image_has_correct_scaling;
-    double scale_factor;
+    double user_specified_scale_factor;
 
     float low_res_filter_value;
     float high_res_filter_value;

--- a/src/gui/PickingBitmapPanel.h
+++ b/src/gui/PickingBitmapPanel.h
@@ -69,20 +69,23 @@ class PickingBitmapPanel : public wxPanel {
     void     OnLeftUp(wxMouseEvent& event);
     void     OnRightDown(wxMouseEvent& event);
     void     OnRightUp(wxMouseEvent& event);
+    void     OnMiddleUp(wxMouseEvent& event);
     void     OnMotion(wxMouseEvent& event);
     wxCursor CreatePaintCursor( );
 
     //
-    bool  should_show;
-    float font_size_multiplier;
-    bool  size_is_dirty;
-    bool  draw_circles_around_particles;
-    bool  should_high_pass;
-    bool  should_low_pass;
-    bool  should_wiener_filter;
-    bool  draw_scale_bar;
-    bool  allow_editing_of_coordinates;
-    bool  popup_exists;
+    bool   should_show;
+    float  font_size_multiplier;
+    bool   size_is_dirty;
+    bool   draw_circles_around_particles;
+    bool   should_high_pass;
+    bool   should_low_pass;
+    bool   should_wiener_filter;
+    bool   draw_scale_bar;
+    bool   allow_editing_of_coordinates;
+    bool   popup_exists;
+    bool   image_has_correct_scaling;
+    double scale_factor;
 
     float low_res_filter_value;
     float high_res_filter_value;
@@ -111,6 +114,10 @@ class PickingBitmapPanel : public wxPanel {
     int   selection_rectangle_start_y;
     int   selection_rectangle_current_x;
     int   selection_rectangle_current_y;
+    long  old_mouse_x;
+    long  old_mouse_y;
+    long  image_in_bitmap_x;
+    long  image_in_bitmap_y;
     float selection_rectangle_start_x_in_angstroms;
     float selection_rectangle_start_y_in_angstroms;
     float selection_rectangle_finish_x_in_angstroms;

--- a/src/gui/PickingResultsDisplayPanel.cpp
+++ b/src/gui/PickingResultsDisplayPanel.cpp
@@ -7,7 +7,6 @@ PickingResultsDisplayPanel::PickingResultsDisplayPanel(wxWindow* parent, wxWindo
     //Bind(wxEVT_COMBOBOX, &ShowPickingResultsPanel::OnFitTypeRadioButton, this);
 
     //CTF2DResultsPanel->font_size_multiplier = 1.5;
-
     PickingResultsImagePanel->UnsetToolTip( );
 
     LowResFilterTextCtrl->SetMinMaxValue(0.1, FLT_MAX);
@@ -155,7 +154,6 @@ void PickingResultsDisplayPanel::OnRedoButtonClick(wxCommandEvent& event) {
 }
 
 void PickingResultsDisplayPanel::OnScalingChange(wxCommandEvent& event) {
-    wxPrintf("PickingResultsDisplayPanel::ChangeImageScaling gets called\n");
     wxString scaling_value = ScalingComboBox->GetValue( );
     if ( scaling_value.Right(1).IsSameAs(wxT("%")) )
         scaling_value.RemoveLast( );

--- a/src/gui/PickingResultsDisplayPanel.cpp
+++ b/src/gui/PickingResultsDisplayPanel.cpp
@@ -154,6 +154,34 @@ void PickingResultsDisplayPanel::OnRedoButtonClick(wxCommandEvent& event) {
     PickingResultsImagePanel->StepForwardInHistoryOfParticleCoordinates( );
 }
 
+void PickingResultsDisplayPanel::OnScalingChange(wxCommandEvent& event) {
+    wxPrintf("PickingResultsDisplayPanel::ChangeImageScaling gets called\n");
+    wxString scaling_value = ScalingComboBox->GetValue( );
+    if ( scaling_value.Right(1).IsSameAs(wxT("%")) )
+        scaling_value.RemoveLast( );
+    bool convert_success;
+    long new_value;
+    convert_success = scaling_value.ToLong(&new_value);
+    if ( convert_success && new_value > 0 && double(new_value) / 100. != PickingResultsImagePanel->scale_factor ) {
+        PickingResultsImagePanel->scale_factor  = double(new_value) / 100;
+        PickingResultsImagePanel->size_is_dirty = true;
+        // TODO: Add a way to redraw the bitmap here, so that the image is scaled in accordance with the newly set scale factor
+        // Want to follow DRY principles, but unsure of best way to get redraw; it may just be as simple as a Refresh()/Update()
+        // and then adding the appropriate resizing code in the drawing of the bitmap
+        PickingResultsImagePanel->UpdateScalingAndDimensions( );
+        PickingResultsImagePanel->UpdateImageInBitmap( );
+        PickingResultsImagePanel->Refresh( );
+        PickingResultsImagePanel->Update( );
+    }
+    // Something was not right; so reset to old scale factor
+    else {
+        wxString temp_string;
+        temp_string = wxString::Format(wxT("%i"), int(myround(PickingResultsImagePanel->scale_factor * 100)));
+        temp_string += wxT("%");
+        ScalingComboBox->SetValue(temp_string);
+    }
+}
+
 void PickingResultsDisplayPanel::SetNumberOfPickedCoordinates(int number_of_coordinates) {
     NumberOfPicksStaticText->SetLabel(wxString::Format(wxT("%i picked coordinates"), number_of_coordinates));
 }

--- a/src/gui/PickingResultsDisplayPanel.cpp
+++ b/src/gui/PickingResultsDisplayPanel.cpp
@@ -160,12 +160,9 @@ void PickingResultsDisplayPanel::OnScalingChange(wxCommandEvent& event) {
     bool convert_success;
     long new_value;
     convert_success = scaling_value.ToLong(&new_value);
-    if ( convert_success && new_value > 0 && double(new_value) / 100. != PickingResultsImagePanel->scale_factor ) {
-        PickingResultsImagePanel->scale_factor  = double(new_value) / 100;
-        PickingResultsImagePanel->size_is_dirty = true;
-        // TODO: Add a way to redraw the bitmap here, so that the image is scaled in accordance with the newly set scale factor
-        // Want to follow DRY principles, but unsure of best way to get redraw; it may just be as simple as a Refresh()/Update()
-        // and then adding the appropriate resizing code in the drawing of the bitmap
+    if ( convert_success && new_value > 0 && double(new_value) / 100. != PickingResultsImagePanel->user_specified_scale_factor ) {
+        PickingResultsImagePanel->user_specified_scale_factor = double(new_value) / 100;
+        PickingResultsImagePanel->size_is_dirty               = true;
         PickingResultsImagePanel->UpdateScalingAndDimensions( );
         PickingResultsImagePanel->UpdateImageInBitmap( );
         PickingResultsImagePanel->Refresh( );
@@ -174,7 +171,7 @@ void PickingResultsDisplayPanel::OnScalingChange(wxCommandEvent& event) {
     // Something was not right; so reset to old scale factor
     else {
         wxString temp_string;
-        temp_string = wxString::Format(wxT("%i"), int(myround(PickingResultsImagePanel->scale_factor * 100)));
+        temp_string = wxString::Format(wxT("%i"), int(myround(PickingResultsImagePanel->user_specified_scale_factor * 100)));
         temp_string += wxT("%");
         ScalingComboBox->SetValue(temp_string);
     }

--- a/src/gui/PickingResultsDisplayPanel.h
+++ b/src/gui/PickingResultsDisplayPanel.h
@@ -23,6 +23,7 @@ class
     void OnScaleBarCheckBox(wxCommandEvent& event);
     void OnUndoButtonClick(wxCommandEvent& event);
     void OnRedoButtonClick(wxCommandEvent& event);
+    void OnScalingChange(wxCommandEvent& event);
 
     void OnLowPassEnter(wxCommandEvent& event);
     void OnLowPassKillFocus(wxFocusEvent& event);

--- a/src/gui/ProjectX_gui_picking.cpp
+++ b/src/gui/ProjectX_gui_picking.cpp
@@ -82,14 +82,14 @@ PickingResultsDisplayPanelParent::PickingResultsDisplayPanelParent( wxWindow* pa
 
 	ScalingComboBox = new wxComboBox( this, wxID_ANY, wxT("100%"), wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
 	ScalingComboBox->Append( wxT("300%") );
+	ScalingComboBox->Append( wxT("250%") );
 	ScalingComboBox->Append( wxT("200%") );
+	ScalingComboBox->Append( wxT("166%") );
 	ScalingComboBox->Append( wxT("150%") );
+	ScalingComboBox->Append( wxT("133%") );
+	ScalingComboBox->Append( wxT("125%") );
 	ScalingComboBox->Append( wxT("100%") );
 	ScalingComboBox->Append( wxT("66%") );
-	ScalingComboBox->Append( wxT("50%") );
-	ScalingComboBox->Append( wxT("33%") );
-	ScalingComboBox->Append( wxT("25%") );
-	ScalingComboBox->Append( wxT("10%") );
 	bSizer35->Add( ScalingComboBox, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
 	ImageScalingText = new wxStaticText( this, wxID_ANY, wxT("Image Scaling"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/gui/ProjectX_gui_picking.cpp
+++ b/src/gui/ProjectX_gui_picking.cpp
@@ -397,7 +397,7 @@ PickingResultsPanel::PickingResultsPanel( wxWindow* parent, wxWindowID id, const
 	wxBoxSizer* bSizer69;
 	bSizer69 = new wxBoxSizer( wxHORIZONTAL );
 
-	m_staticText469 = new wxStaticText( RightPanel, wxID_ANY, wxT("Left-Click on particles to select/deselect.\nCtrl-Left-Click to rubberband area and deselect.\nShift-Left-Click to paint area and deselect."), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText469 = new wxStaticText( RightPanel, wxID_ANY, wxT("Left-Click on particles to select/deselect.\nCtrl-Left-Click to rubberband area and deselect.\nShift-Left-Click to paint area and deselect.\nRight-Click for zoomed sub-view."), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText469->Wrap( -1 );
 	bSizer69->Add( m_staticText469, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 

--- a/src/gui/ProjectX_gui_picking.cpp
+++ b/src/gui/ProjectX_gui_picking.cpp
@@ -77,6 +77,28 @@ PickingResultsDisplayPanelParent::PickingResultsDisplayPanelParent( wxWindow* pa
 
 	bSizer94->Add( WienerFilterCheckBox, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
+	wxBoxSizer* bSizer35;
+	bSizer35 = new wxBoxSizer( wxHORIZONTAL );
+
+	ScalingComboBox = new wxComboBox( this, wxID_ANY, wxT("100%"), wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
+	ScalingComboBox->Append( wxT("300%") );
+	ScalingComboBox->Append( wxT("200%") );
+	ScalingComboBox->Append( wxT("150%") );
+	ScalingComboBox->Append( wxT("100%") );
+	ScalingComboBox->Append( wxT("66%") );
+	ScalingComboBox->Append( wxT("50%") );
+	ScalingComboBox->Append( wxT("33%") );
+	ScalingComboBox->Append( wxT("25%") );
+	ScalingComboBox->Append( wxT("10%") );
+	bSizer35->Add( ScalingComboBox, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+
+	ImageScalingText = new wxStaticText( this, wxID_ANY, wxT("Image Scaling"), wxDefaultPosition, wxDefaultSize, 0 );
+	ImageScalingText->Wrap( -1 );
+	bSizer35->Add( ImageScalingText, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+
+
+	bSizer94->Add( bSizer35, 0, wxEXPAND, 5 );
+
 	m_staticline831 = new wxStaticLine( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
 	bSizer94->Add( m_staticline831, 0, wxEXPAND | wxALL, 5 );
 
@@ -138,6 +160,8 @@ PickingResultsDisplayPanelParent::PickingResultsDisplayPanelParent( wxWindow* pa
 	LowResFilterTextCtrl->Connect( wxEVT_KILL_FOCUS, wxFocusEventHandler( PickingResultsDisplayPanelParent::OnLowPassKillFocus ), NULL, this );
 	LowResFilterTextCtrl->Connect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnLowPassEnter ), NULL, this );
 	WienerFilterCheckBox->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnWienerFilterCheckBox ), NULL, this );
+	ScalingComboBox->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnScalingChange ), NULL, this );
+	ScalingComboBox->Connect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnScalingChange ), NULL, this );
 	UndoButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnUndoButtonClick ), NULL, this );
 	RedoButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnRedoButtonClick ), NULL, this );
 }
@@ -152,6 +176,8 @@ PickingResultsDisplayPanelParent::~PickingResultsDisplayPanelParent()
 	LowResFilterTextCtrl->Disconnect( wxEVT_KILL_FOCUS, wxFocusEventHandler( PickingResultsDisplayPanelParent::OnLowPassKillFocus ), NULL, this );
 	LowResFilterTextCtrl->Disconnect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnLowPassEnter ), NULL, this );
 	WienerFilterCheckBox->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnWienerFilterCheckBox ), NULL, this );
+	ScalingComboBox->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnScalingChange ), NULL, this );
+	ScalingComboBox->Disconnect( wxEVT_COMMAND_TEXT_ENTER, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnScalingChange ), NULL, this );
 	UndoButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnUndoButtonClick ), NULL, this );
 	RedoButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( PickingResultsDisplayPanelParent::OnRedoButtonClick ), NULL, this );
 

--- a/src/gui/ProjectX_gui_picking.cpp
+++ b/src/gui/ProjectX_gui_picking.cpp
@@ -82,12 +82,11 @@ PickingResultsDisplayPanelParent::PickingResultsDisplayPanelParent( wxWindow* pa
 
 	ScalingComboBox = new wxComboBox( this, wxID_ANY, wxT("100%"), wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
 	ScalingComboBox->Append( wxT("300%") );
-	ScalingComboBox->Append( wxT("250%") );
+	ScalingComboBox->Append( wxT("266%") );
+	ScalingComboBox->Append( wxT("233%") );
 	ScalingComboBox->Append( wxT("200%") );
 	ScalingComboBox->Append( wxT("166%") );
-	ScalingComboBox->Append( wxT("150%") );
 	ScalingComboBox->Append( wxT("133%") );
-	ScalingComboBox->Append( wxT("125%") );
 	ScalingComboBox->Append( wxT("100%") );
 	ScalingComboBox->Append( wxT("66%") );
 	bSizer35->Add( ScalingComboBox, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );

--- a/src/gui/ProjectX_gui_picking.cpp
+++ b/src/gui/ProjectX_gui_picking.cpp
@@ -422,7 +422,7 @@ PickingResultsPanel::PickingResultsPanel( wxWindow* parent, wxWindowID id, const
 	wxBoxSizer* bSizer69;
 	bSizer69 = new wxBoxSizer( wxHORIZONTAL );
 
-	m_staticText469 = new wxStaticText( RightPanel, wxID_ANY, wxT("Left-Click on particles to select/deselect.\nCtrl-Left-Click to rubberband area and deselect.\nShift-Left-Click to paint area and deselect.\nRight-Click for zoomed sub-view."), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText469 = new wxStaticText( RightPanel, wxID_ANY, wxT("Left-Click on particles to select/deselect.\nCtrl-Left-Click to rubberband area and deselect.\nShift-Left-Click to paint area and deselect.\nRight-Click for zoomed sub-view.\nMiddle-Mouse-Hold when zoomed to drag across image."), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText469->Wrap( -1 );
 	bSizer69->Add( m_staticText469, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 

--- a/src/gui/ProjectX_gui_picking.h
+++ b/src/gui/ProjectX_gui_picking.h
@@ -28,6 +28,7 @@ class ResultsDataViewListCtrl;
 #include <wx/textctrl.h>
 #include <wx/stattext.h>
 #include <wx/sizer.h>
+#include <wx/combobox.h>
 #include <wx/statline.h>
 #include <wx/button.h>
 #include <wx/bitmap.h>
@@ -36,7 +37,6 @@ class ResultsDataViewListCtrl;
 #include <wx/radiobut.h>
 #include <wx/tglbtn.h>
 #include <wx/dataview.h>
-#include <wx/combobox.h>
 #include <wx/splitter.h>
 #include <wx/spinctrl.h>
 #include <wx/choice.h>
@@ -77,12 +77,15 @@ class PickingResultsDisplayPanelParent : public wxPanel
 		virtual void OnLowPassKillFocus( wxFocusEvent& event ) { event.Skip(); }
 		virtual void OnLowPassEnter( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnWienerFilterCheckBox( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnScalingChange( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnUndoButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnRedoButtonClick( wxCommandEvent& event ) { event.Skip(); }
 
 
 	public:
 		PickingBitmapPanel* PickingResultsImagePanel;
+		wxComboBox* ScalingComboBox;
+		wxStaticText* ImageScalingText;
 		wxButton* UndoButton;
 		wxButton* RedoButton;
 

--- a/src/gui/gui_functions.cpp
+++ b/src/gui/gui_functions.cpp
@@ -3,92 +3,20 @@
 
 extern MyMainFrame* main_frame;
 
-void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast) {
-    MyDebugAssertTrue(input_image->logical_z_dimension == 1, "Only 2D images can be used");
-    MyDebugAssertTrue(output_bitmap->GetDepth( ) == 24, "bitmap should be 24 bit");
-
-    float image_min_value;
-    float image_max_value;
-    float range;
-    float inverse_range;
-
-    int current_grey_value;
-    int i, j;
-
-    long mirror_line_address;
-
-    int bitmap_x;
-    int bitmap_y;
-
-    if ( input_image->logical_x_dimension != output_bitmap->GetWidth( ) || input_image->logical_y_dimension != output_bitmap->GetHeight( ) ) {
-        output_bitmap->Create(input_image->logical_x_dimension, input_image->logical_y_dimension, 24);
-    }
-
-    if ( auto_contrast == false ) {
-
-        input_image->GetMinMax(image_min_value, image_max_value);
-    }
-    else {
-        float average_value = input_image->ReturnAverageOfRealValues( );
-        float variance      = input_image->ReturnVarianceOfRealValues( );
-        float stdev         = sqrt(variance);
-
-        image_min_value = average_value - (stdev * 2.5);
-        image_max_value = average_value + (stdev * 2.5);
-    }
-
-    range         = image_max_value - image_min_value;
-    inverse_range = 1. / range;
-    inverse_range *= 256.;
-
-    wxNativePixelData pixel_data(*output_bitmap);
-
-    if ( ! pixel_data ) {
-        MyPrintWithDetails("Can't access bitmap data");
-        DEBUG_ABORT;
-    }
-
-    wxNativePixelData::Iterator p(pixel_data);
-    p.Reset(pixel_data);
-
-    // we have to mirror the lines as wxwidgets using 0,0 at top left
-    for ( j = 0; j < input_image->logical_y_dimension; j++ ) {
-        mirror_line_address = (input_image->logical_y_dimension - 1 - j) * (input_image->logical_x_dimension + input_image->padding_jump_value);
-        p.MoveTo(pixel_data, 0, j);
-
-        for ( i = 0; i < input_image->logical_x_dimension; i++ ) {
-            //mirror_line_address = input_image->ReturnReal1DAddressFromPhysicalCoord(i,j,0);
-            current_grey_value = myroundint((input_image->real_values[mirror_line_address] - image_min_value) * inverse_range);
-
-            if ( current_grey_value < 0 )
-                current_grey_value = 0;
-            else if ( current_grey_value > 255 )
-                current_grey_value = 255;
-
-            p.Red( )   = current_grey_value;
-            p.Green( ) = current_grey_value;
-            p.Blue( )  = current_grey_value;
-
-            p++;
-            mirror_line_address++;
-        }
-    }
-}
-
 /**
- * @brief Overload; converts a given image into a bitmap for usage in a display panel. Created to enable
- * ability to zoom in on picking panels while retaining proper coordinate placement.
+ * @brief Converts a given image into a bitmap for usage in a panel that will display
+ *  the bitmap.
  * 
  * @param input_image Image to be converted.
  * @param output_bitmap Bitmap being filled.
+ * @param auto_contrast Sets whether the contrast will be maximal.
  * @param client_x_size X-dim of panel the bitmap will be placed in.
  * @param client_y_size Y-dim of panel the bitmap will be placed in.
  * @param img_x_start Starting x-coord for getting bitmap data.
  * @param img_y_start Starting y-coord for getting bitmap data.
- * @param scaling_factor I.e. zoom level; the value logical dimensions were actually multiplied by.
- * @param auto_contrast Sets whether the contrast will be maximal.
+ * @param scaling_factor I.e. zoom level; the value by which the logical dimensions of input_image were scaled.
  */
-void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int client_x_size, int client_y_size, int img_x_start, int img_y_start, float scaling_factor, bool auto_contrast) {
+void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast, int client_x_size, int client_y_size, int img_x_start, int img_y_start, float scaling_factor) {
     MyDebugAssertTrue(input_image->logical_z_dimension == 1, "Only 2D images can be used");
     MyDebugAssertTrue(output_bitmap->GetDepth( ) == 24, "bitmap should be 24 bit");
 
@@ -102,13 +30,14 @@ void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int clien
 
     long mirror_line_address;
 
-    // TODO: change allocated size of the bitmap, then try to implement an algo in which the
-    // data loaded is limited maximally to the size of the client.
-    // This should save the time that needs to be saved on dragging
-
-    if ( input_image->logical_x_dimension != output_bitmap->GetWidth( ) || input_image->logical_y_dimension != output_bitmap->GetHeight( ) ) {
-        output_bitmap->Create(input_image->logical_x_dimension, input_image->logical_y_dimension, 24);
-    }
+    //  Assign bitmap size to the smaller dimension between the client panel and the scaled image dimensions
+    //  The purpose of this is to avoid reading the entire image from memory each time PickingBitmapPanel::OnMotion
+    //  is called, resulting in a smoother drag with what would otherwise be a very large number of pixels to load.
+    int final_width, final_height;
+    final_width  = std::min(input_image->logical_x_dimension, client_x_size);
+    final_height = std::min(input_image->logical_y_dimension, client_y_size);
+    if ( final_width != output_bitmap->GetWidth( ) || final_height != output_bitmap->GetHeight( ) )
+        output_bitmap->Create(final_width, final_height, 24);
 
     if ( auto_contrast == false ) {
         input_image->GetMinMax(image_min_value, image_max_value);
@@ -135,17 +64,16 @@ void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int clien
     wxNativePixelData::Iterator p(pixel_data);
     p.Reset(pixel_data);
 
-    // we have to mirror the lines as wxwidgets using 0,0 at top left
-    // Get all of the image data, and then take a subsection of it for actually creating the bitmap,
-    // which should be limited by the panel's or the image's size, whichever is smaller
-    for ( j = 0; j < input_image->logical_y_dimension; j++ ) {
-        mirror_line_address = (input_image->logical_y_dimension - 1 - j) * (input_image->logical_x_dimension + input_image->padding_jump_value);
+    // Still start at 0, but instead of allowing the address to be determined this way, set the value ahead of time.
+    // This maintains proper place in the bitmap, while shifting us to be in the correct position for the image
+    for ( j = 0; j < final_height; j++ ) {
+        int image_y = static_cast<int>(img_y_start * scaling_factor) + j;
         p.MoveTo(pixel_data, 0, j);
+        for ( i = 0; i < final_width; i++ ) {
+            int image_x         = static_cast<int>(img_x_start * scaling_factor) + i;
+            mirror_line_address = input_image->ReturnReal1DAddressFromPhysicalCoord(image_x, input_image->logical_y_dimension - 1 - image_y, 0);
 
-        for ( i = 0; i < input_image->logical_x_dimension; i++ ) {
-            //mirror_line_address = input_image->ReturnReal1DAddressFromPhysicalCoord(i,j,0);
             current_grey_value = myroundint((input_image->real_values[mirror_line_address] - image_min_value) * inverse_range);
-
             if ( current_grey_value < 0 )
                 current_grey_value = 0;
             else if ( current_grey_value > 255 )
@@ -156,19 +84,8 @@ void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int clien
             p.Blue( )  = current_grey_value;
 
             p++;
-            mirror_line_address++;
         }
     }
-
-    // Now get sub-image dimensions and create it.
-    int cut_x_size = (client_x_size < input_image->logical_x_dimension) ? client_x_size : input_image->logical_x_dimension;
-    int cut_y_size = (client_y_size < input_image->logical_y_dimension) ? client_y_size : input_image->logical_y_dimension;
-    if ( img_x_start * scaling_factor + client_x_size > input_image->logical_x_dimension )
-        cut_x_size = input_image->logical_x_dimension - img_x_start * scaling_factor;
-    if ( img_y_start * scaling_factor + client_y_size > input_image->logical_y_dimension )
-        cut_y_size = input_image->logical_y_dimension - img_y_start * scaling_factor;
-
-    *output_bitmap = output_bitmap->GetSubBitmap(wxRect(img_x_start * scaling_factor, img_y_start * scaling_factor, cut_x_size, cut_y_size));
 }
 
 void GetMultilineTextExtent(wxDC* wanted_dc, const wxString& string, int& width, int& height) {

--- a/src/gui/gui_functions.cpp
+++ b/src/gui/gui_functions.cpp
@@ -102,6 +102,10 @@ void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int clien
 
     long mirror_line_address;
 
+    // TODO: change allocated size of the bitmap, then try to implement an algo in which the
+    // data loaded is limited maximally to the size of the client.
+    // This should save the time that needs to be saved on dragging
+
     if ( input_image->logical_x_dimension != output_bitmap->GetWidth( ) || input_image->logical_y_dimension != output_bitmap->GetHeight( ) ) {
         output_bitmap->Create(input_image->logical_x_dimension, input_image->logical_y_dimension, 24);
     }

--- a/src/gui/gui_functions.cpp
+++ b/src/gui/gui_functions.cpp
@@ -73,6 +73,83 @@ void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto
     }
 }
 
+// Overload ConvertImageToBitmap to enable getting a scaled form of the image -- could potentially just replace this function with default values
+void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, double scale_factor, bool auto_contrast) {
+    MyDebugAssertTrue(input_image->logical_z_dimension == 1, "Only 2D images can be used");
+    MyDebugAssertTrue(output_bitmap->GetDepth( ) == 24, "bitmap should be 24 bit");
+
+    float image_min_value;
+    float image_max_value;
+    float range;
+    float inverse_range;
+
+    int current_grey_value;
+    int i, j;
+
+    long mirror_line_address;
+    long address = 0;
+
+    wxImage scaled_image;
+
+    // TODO: add modifications to account for scaling when scaling is not 1
+    if ( scale_factor != 1.0 ) {
+    }
+
+    if ( input_image->logical_x_dimension != output_bitmap->GetWidth( ) || input_image->logical_y_dimension != output_bitmap->GetHeight( ) ) {
+        output_bitmap->Create(input_image->logical_x_dimension, input_image->logical_y_dimension, 24);
+    }
+
+    if ( auto_contrast == false ) {
+
+        input_image->GetMinMax(image_min_value, image_max_value);
+    }
+    else {
+        float average_value = input_image->ReturnAverageOfRealValues( );
+        float variance      = input_image->ReturnVarianceOfRealValues( );
+        float stdev         = sqrt(variance);
+
+        image_min_value = average_value - (stdev * 2.5);
+        image_max_value = average_value + (stdev * 2.5);
+    }
+
+    range         = image_max_value - image_min_value;
+    inverse_range = 1. / range;
+    inverse_range *= 256.;
+
+    wxNativePixelData pixel_data(*output_bitmap);
+
+    if ( ! pixel_data ) {
+        MyPrintWithDetails("Can't access bitmap data");
+        DEBUG_ABORT;
+    }
+
+    wxNativePixelData::Iterator p(pixel_data);
+    p.Reset(pixel_data);
+
+    // we have to mirror the lines as wxwidgets using 0,0 at top left
+    for ( j = 0; j < input_image->logical_y_dimension; j++ ) {
+        mirror_line_address = (input_image->logical_y_dimension - 1 - j) * (input_image->logical_x_dimension + input_image->padding_jump_value);
+        p.MoveTo(pixel_data, 0, j);
+
+        for ( i = 0; i < input_image->logical_x_dimension; i++ ) {
+            //mirror_line_address = input_image->ReturnReal1DAddressFromPhysicalCoord(i,j,0);
+            current_grey_value = myroundint((input_image->real_values[mirror_line_address] - image_min_value) * inverse_range);
+
+            if ( current_grey_value < 0 )
+                current_grey_value = 0;
+            else if ( current_grey_value > 255 )
+                current_grey_value = 255;
+
+            p.Red( )   = current_grey_value;
+            p.Green( ) = current_grey_value;
+            p.Blue( )  = current_grey_value;
+
+            p++;
+            mirror_line_address++;
+        }
+    }
+}
+
 void GetMultilineTextExtent(wxDC* wanted_dc, const wxString& string, int& width, int& height) {
     wxStringTokenizer tokens(string, "\n");
     wxString          current_token;

--- a/src/gui/gui_functions.h
+++ b/src/gui/gui_functions.h
@@ -1,7 +1,6 @@
 
 
-void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast = false);
-void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int client_x_size, int client_y_size, int img_x_start, int img_y_start, float scaling_factor, bool auto_contrast = false);
+void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast = false, int client_x_size = INT_MAX, int client_y_size = INT_MAX, int img_x_start = 0, int img_y_start = 0, float scaling_factor = 0.0);
 void GetMultilineTextExtent(wxDC* wanted_dc, const wxString& string, int& width, int& height);
 void FillGroupComboBoxWorker(wxComboBox* GroupComboBox, bool include_all_images_group = true);
 void FillParticlePositionsGroupComboBox(wxComboBox* GroupComboBox, bool include_all_particle_positions_group = true);

--- a/src/gui/gui_functions.h
+++ b/src/gui/gui_functions.h
@@ -1,7 +1,8 @@
 
 
 void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast = false);
-void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, double scale_factor, bool auto_contrast = false);
+void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int client_x_size, int client_y_size, int img_x, int img_y, float scaling_factor, bool auto_contrast = false);
+//void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, double scale_factor, int cut_x_size, int cut_y_size, int image_x, int image_y, bool auto_contrast = false);
 void GetMultilineTextExtent(wxDC* wanted_dc, const wxString& string, int& width, int& height);
 void FillGroupComboBoxWorker(wxComboBox* GroupComboBox, bool include_all_images_group = true);
 void FillParticlePositionsGroupComboBox(wxComboBox* GroupComboBox, bool include_all_particle_positions_group = true);

--- a/src/gui/gui_functions.h
+++ b/src/gui/gui_functions.h
@@ -1,6 +1,7 @@
 
 
 void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast = false);
+void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, double scale_factor, bool auto_contrast = false);
 void GetMultilineTextExtent(wxDC* wanted_dc, const wxString& string, int& width, int& height);
 void FillGroupComboBoxWorker(wxComboBox* GroupComboBox, bool include_all_images_group = true);
 void FillParticlePositionsGroupComboBox(wxComboBox* GroupComboBox, bool include_all_particle_positions_group = true);

--- a/src/gui/gui_functions.h
+++ b/src/gui/gui_functions.h
@@ -1,7 +1,7 @@
 
 
 void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast = false);
-void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int client_x_size, int client_y_size, int img_x, int img_y, float scaling_factor, bool auto_contrast = false);
+void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int client_x_size, int client_y_size, int img_x_start, int img_y_start, float scaling_factor, bool auto_contrast = false);
 //void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, double scale_factor, int cut_x_size, int cut_y_size, int image_x, int image_y, bool auto_contrast = false);
 void GetMultilineTextExtent(wxDC* wanted_dc, const wxString& string, int& width, int& height);
 void FillGroupComboBoxWorker(wxComboBox* GroupComboBox, bool include_all_images_group = true);

--- a/src/gui/gui_functions.h
+++ b/src/gui/gui_functions.h
@@ -2,7 +2,6 @@
 
 void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, bool auto_contrast = false);
 void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, int client_x_size, int client_y_size, int img_x_start, int img_y_start, float scaling_factor, bool auto_contrast = false);
-//void ConvertImageToBitmap(Image* input_image, wxBitmap* output_bitmap, double scale_factor, int cut_x_size, int cut_y_size, int image_x, int image_y, bool auto_contrast = false);
 void GetMultilineTextExtent(wxDC* wanted_dc, const wxString& string, int& width, int& height);
 void FillGroupComboBoxWorker(wxComboBox* GroupComboBox, bool include_all_images_group = true);
 void FillParticlePositionsGroupComboBox(wxComboBox* GroupComboBox, bool include_all_particle_positions_group = true);

--- a/src/gui/wxformbuilder/ProjectX_picking.fbp
+++ b/src/gui/wxformbuilder/ProjectX_picking.fbp
@@ -622,7 +622,7 @@
                                                 <property name="caption"></property>
                                                 <property name="caption_visible">1</property>
                                                 <property name="center_pane">0</property>
-                                                <property name="choices">&quot;300%&quot; &quot;200%&quot; &quot;150%&quot; &quot;100%&quot; &quot;66%&quot; &quot;50%&quot; &quot;33%&quot; &quot;25%&quot; &quot;10%&quot;</property>
+                                                <property name="choices">&quot;300%&quot; &quot;250%&quot; &quot;200%&quot; &quot;166%&quot; &quot;150%&quot; &quot;133%&quot; &quot;125%&quot; &quot;100%&quot; &quot;66%&quot;</property>
                                                 <property name="close_button">1</property>
                                                 <property name="context_help"></property>
                                                 <property name="context_menu">1</property>

--- a/src/gui/wxformbuilder/ProjectX_picking.fbp
+++ b/src/gui/wxformbuilder/ProjectX_picking.fbp
@@ -3842,7 +3842,7 @@
                                                     <property name="gripper">0</property>
                                                     <property name="hidden">0</property>
                                                     <property name="id">wxID_ANY</property>
-                                                    <property name="label">Left-Click on particles to select/deselect.&#x0A;Ctrl-Left-Click to rubberband area and deselect.&#x0A;Shift-Left-Click to paint area and deselect.</property>
+                                                    <property name="label">Left-Click on particles to select/deselect.&#x0A;Ctrl-Left-Click to rubberband area and deselect.&#x0A;Shift-Left-Click to paint area and deselect.&#x0A;Right-Click for zoomed sub-view.</property>
                                                     <property name="markup">0</property>
                                                     <property name="max_size"></property>
                                                     <property name="maximize_button">0</property>

--- a/src/gui/wxformbuilder/ProjectX_picking.fbp
+++ b/src/gui/wxformbuilder/ProjectX_picking.fbp
@@ -29,7 +29,7 @@
         <property name="use_array_enum">0</property>
         <property name="use_enum">1</property>
         <property name="use_microsoft_bom">0</property>
-        <object class="Panel" expanded="0">
+        <object class="Panel" expanded="1">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -52,7 +52,7 @@
             <property name="window_extra_style"></property>
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL</property>
-            <object class="wxBoxSizer" expanded="0">
+            <object class="wxBoxSizer" expanded="1">
                 <property name="minimum_size"></property>
                 <property name="name">bSizer92</property>
                 <property name="orient">wxHORIZONTAL</property>
@@ -114,20 +114,20 @@
                         <property name="window_style">wxTAB_TRAVERSAL</property>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="0">
+                <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">1</property>
-                    <object class="wxBoxSizer" expanded="0">
+                    <object class="wxBoxSizer" expanded="1">
                         <property name="minimum_size"></property>
                         <property name="name">bSizer93</property>
                         <property name="orient">wxHORIZONTAL</property>
                         <property name="permission">none</property>
-                        <object class="sizeritem" expanded="0">
+                        <object class="sizeritem" expanded="1">
                             <property name="border">5</property>
                             <property name="flag">wxALIGN_CENTER|wxEXPAND</property>
                             <property name="proportion">1</property>
-                            <object class="wxBoxSizer" expanded="0">
+                            <object class="wxBoxSizer" expanded="1">
                                 <property name="minimum_size"></property>
                                 <property name="name">bSizer94</property>
                                 <property name="orient">wxVERTICAL</property>
@@ -327,11 +327,11 @@
                                         <event name="OnCheckBox">OnHighPassFilterCheckBox</event>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="0">
+                                <object class="sizeritem" expanded="1">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxBoxSizer" expanded="0">
+                                    <object class="wxBoxSizer" expanded="1">
                                         <property name="minimum_size"></property>
                                         <property name="name">bSizer487</property>
                                         <property name="orient">wxHORIZONTAL</property>
@@ -593,6 +593,145 @@
                                         <property name="window_name"></property>
                                         <property name="window_style"></property>
                                         <event name="OnCheckBox">OnWienerFilterCheckBox</event>
+                                    </object>
+                                </object>
+                                <object class="sizeritem" expanded="1">
+                                    <property name="border">5</property>
+                                    <property name="flag">wxEXPAND</property>
+                                    <property name="proportion">0</property>
+                                    <object class="wxBoxSizer" expanded="1">
+                                        <property name="minimum_size"></property>
+                                        <property name="name">bSizer35</property>
+                                        <property name="orient">wxHORIZONTAL</property>
+                                        <property name="permission">none</property>
+                                        <object class="sizeritem" expanded="1">
+                                            <property name="border">5</property>
+                                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
+                                            <property name="proportion">0</property>
+                                            <object class="wxComboBox" expanded="1">
+                                                <property name="BottomDockable">1</property>
+                                                <property name="LeftDockable">1</property>
+                                                <property name="RightDockable">1</property>
+                                                <property name="TopDockable">1</property>
+                                                <property name="aui_layer"></property>
+                                                <property name="aui_name"></property>
+                                                <property name="aui_position"></property>
+                                                <property name="aui_row"></property>
+                                                <property name="best_size"></property>
+                                                <property name="bg"></property>
+                                                <property name="caption"></property>
+                                                <property name="caption_visible">1</property>
+                                                <property name="center_pane">0</property>
+                                                <property name="choices">&quot;300%&quot; &quot;200%&quot; &quot;150%&quot; &quot;100%&quot; &quot;66%&quot; &quot;50%&quot; &quot;33%&quot; &quot;25%&quot; &quot;10%&quot;</property>
+                                                <property name="close_button">1</property>
+                                                <property name="context_help"></property>
+                                                <property name="context_menu">1</property>
+                                                <property name="default_pane">0</property>
+                                                <property name="dock">Dock</property>
+                                                <property name="dock_fixed">0</property>
+                                                <property name="docking">Left</property>
+                                                <property name="enabled">1</property>
+                                                <property name="fg"></property>
+                                                <property name="floatable">1</property>
+                                                <property name="font"></property>
+                                                <property name="gripper">0</property>
+                                                <property name="hidden">0</property>
+                                                <property name="id">wxID_ANY</property>
+                                                <property name="max_size"></property>
+                                                <property name="maximize_button">0</property>
+                                                <property name="maximum_size"></property>
+                                                <property name="min_size"></property>
+                                                <property name="minimize_button">0</property>
+                                                <property name="minimum_size"></property>
+                                                <property name="moveable">1</property>
+                                                <property name="name">ScalingComboBox</property>
+                                                <property name="pane_border">1</property>
+                                                <property name="pane_position"></property>
+                                                <property name="pane_size"></property>
+                                                <property name="permission">public</property>
+                                                <property name="pin_button">1</property>
+                                                <property name="pos"></property>
+                                                <property name="resize">Resizable</property>
+                                                <property name="selection">-1</property>
+                                                <property name="show">1</property>
+                                                <property name="size"></property>
+                                                <property name="style"></property>
+                                                <property name="subclass">; ; forward_declare</property>
+                                                <property name="toolbar_pane">0</property>
+                                                <property name="tooltip"></property>
+                                                <property name="validator_data_type"></property>
+                                                <property name="validator_style">wxFILTER_NONE</property>
+                                                <property name="validator_type">wxDefaultValidator</property>
+                                                <property name="validator_variable"></property>
+                                                <property name="value">100%</property>
+                                                <property name="window_extra_style"></property>
+                                                <property name="window_name"></property>
+                                                <property name="window_style"></property>
+                                                <event name="OnCombobox">OnScalingChange</event>
+                                                <event name="OnTextEnter">OnScalingChange</event>
+                                            </object>
+                                        </object>
+                                        <object class="sizeritem" expanded="1">
+                                            <property name="border">5</property>
+                                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
+                                            <property name="proportion">0</property>
+                                            <object class="wxStaticText" expanded="1">
+                                                <property name="BottomDockable">1</property>
+                                                <property name="LeftDockable">1</property>
+                                                <property name="RightDockable">1</property>
+                                                <property name="TopDockable">1</property>
+                                                <property name="aui_layer"></property>
+                                                <property name="aui_name"></property>
+                                                <property name="aui_position"></property>
+                                                <property name="aui_row"></property>
+                                                <property name="best_size"></property>
+                                                <property name="bg"></property>
+                                                <property name="caption"></property>
+                                                <property name="caption_visible">1</property>
+                                                <property name="center_pane">0</property>
+                                                <property name="close_button">1</property>
+                                                <property name="context_help"></property>
+                                                <property name="context_menu">1</property>
+                                                <property name="default_pane">0</property>
+                                                <property name="dock">Dock</property>
+                                                <property name="dock_fixed">0</property>
+                                                <property name="docking">Left</property>
+                                                <property name="enabled">1</property>
+                                                <property name="fg"></property>
+                                                <property name="floatable">1</property>
+                                                <property name="font"></property>
+                                                <property name="gripper">0</property>
+                                                <property name="hidden">0</property>
+                                                <property name="id">wxID_ANY</property>
+                                                <property name="label">Image Scaling</property>
+                                                <property name="markup">0</property>
+                                                <property name="max_size"></property>
+                                                <property name="maximize_button">0</property>
+                                                <property name="maximum_size"></property>
+                                                <property name="min_size"></property>
+                                                <property name="minimize_button">0</property>
+                                                <property name="minimum_size"></property>
+                                                <property name="moveable">1</property>
+                                                <property name="name">ImageScalingText</property>
+                                                <property name="pane_border">1</property>
+                                                <property name="pane_position"></property>
+                                                <property name="pane_size"></property>
+                                                <property name="permission">public</property>
+                                                <property name="pin_button">1</property>
+                                                <property name="pos"></property>
+                                                <property name="resize">Resizable</property>
+                                                <property name="show">1</property>
+                                                <property name="size"></property>
+                                                <property name="style"></property>
+                                                <property name="subclass">; ; forward_declare</property>
+                                                <property name="toolbar_pane">0</property>
+                                                <property name="tooltip"></property>
+                                                <property name="window_extra_style"></property>
+                                                <property name="window_name"></property>
+                                                <property name="window_style"></property>
+                                                <property name="wrap">-1</property>
+                                            </object>
+                                        </object>
                                     </object>
                                 </object>
                                 <object class="sizeritem" expanded="0">
@@ -955,11 +1094,11 @@
                                         <property name="window_style"></property>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="0">
+                                <object class="sizeritem" expanded="1">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxBoxSizer" expanded="0">
+                                    <object class="wxBoxSizer" expanded="1">
                                         <property name="minimum_size"></property>
                                         <property name="name">bSizer488</property>
                                         <property name="orient">wxHORIZONTAL</property>
@@ -1178,7 +1317,7 @@
                 </object>
             </object>
         </object>
-        <object class="Panel" expanded="0">
+        <object class="Panel" expanded="1">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -1202,7 +1341,7 @@
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL</property>
             <event name="OnUpdateUI">OnUpdateUI</event>
-            <object class="wxBoxSizer" expanded="0">
+            <object class="wxBoxSizer" expanded="1">
                 <property name="minimum_size"></property>
                 <property name="name">bSizer63</property>
                 <property name="orient">wxVERTICAL</property>
@@ -1265,11 +1404,11 @@
                         <property name="window_style"></property>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="0">
+                <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">1</property>
-                    <object class="wxSplitterWindow" expanded="0">
+                    <object class="wxSplitterWindow" expanded="1">
                         <property name="BottomDockable">1</property>
                         <property name="LeftDockable">1</property>
                         <property name="RightDockable">1</property>
@@ -1326,8 +1465,8 @@
                         <property name="window_extra_style"></property>
                         <property name="window_name"></property>
                         <property name="window_style"></property>
-                        <object class="splitteritem" expanded="0">
-                            <object class="wxPanel" expanded="0">
+                        <object class="splitteritem" expanded="1">
+                            <object class="wxPanel" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -1378,7 +1517,7 @@
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style">wxTAB_TRAVERSAL</property>
-                                <object class="wxBoxSizer" expanded="0">
+                                <object class="wxBoxSizer" expanded="1">
                                     <property name="minimum_size"></property>
                                     <property name="name">bSizer66</property>
                                     <property name="orient">wxVERTICAL</property>
@@ -1937,8 +2076,8 @@
                                 </object>
                             </object>
                         </object>
-                        <object class="splitteritem" expanded="0">
-                            <object class="wxPanel" expanded="0">
+                        <object class="splitteritem" expanded="1">
+                            <object class="wxPanel" expanded="1">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>

--- a/src/gui/wxformbuilder/ProjectX_picking.fbp
+++ b/src/gui/wxformbuilder/ProjectX_picking.fbp
@@ -29,7 +29,7 @@
         <property name="use_array_enum">0</property>
         <property name="use_enum">1</property>
         <property name="use_microsoft_bom">0</property>
-        <object class="Panel" expanded="1">
+        <object class="Panel" expanded="0">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -52,7 +52,7 @@
             <property name="window_extra_style"></property>
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL</property>
-            <object class="wxBoxSizer" expanded="1">
+            <object class="wxBoxSizer" expanded="0">
                 <property name="minimum_size"></property>
                 <property name="name">bSizer92</property>
                 <property name="orient">wxHORIZONTAL</property>
@@ -114,20 +114,20 @@
                         <property name="window_style">wxTAB_TRAVERSAL</property>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="1">
+                <object class="sizeritem" expanded="0">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">1</property>
-                    <object class="wxBoxSizer" expanded="1">
+                    <object class="wxBoxSizer" expanded="0">
                         <property name="minimum_size"></property>
                         <property name="name">bSizer93</property>
                         <property name="orient">wxHORIZONTAL</property>
                         <property name="permission">none</property>
-                        <object class="sizeritem" expanded="1">
+                        <object class="sizeritem" expanded="0">
                             <property name="border">5</property>
                             <property name="flag">wxALIGN_CENTER|wxEXPAND</property>
                             <property name="proportion">1</property>
-                            <object class="wxBoxSizer" expanded="1">
+                            <object class="wxBoxSizer" expanded="0">
                                 <property name="minimum_size"></property>
                                 <property name="name">bSizer94</property>
                                 <property name="orient">wxVERTICAL</property>
@@ -327,11 +327,11 @@
                                         <event name="OnCheckBox">OnHighPassFilterCheckBox</event>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="1">
+                                <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxBoxSizer" expanded="1">
+                                    <object class="wxBoxSizer" expanded="0">
                                         <property name="minimum_size"></property>
                                         <property name="name">bSizer487</property>
                                         <property name="orient">wxHORIZONTAL</property>
@@ -595,20 +595,20 @@
                                         <event name="OnCheckBox">OnWienerFilterCheckBox</event>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="1">
+                                <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxBoxSizer" expanded="1">
+                                    <object class="wxBoxSizer" expanded="0">
                                         <property name="minimum_size"></property>
                                         <property name="name">bSizer35</property>
                                         <property name="orient">wxHORIZONTAL</property>
                                         <property name="permission">none</property>
-                                        <object class="sizeritem" expanded="1">
+                                        <object class="sizeritem" expanded="0">
                                             <property name="border">5</property>
                                             <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
                                             <property name="proportion">0</property>
-                                            <object class="wxComboBox" expanded="1">
+                                            <object class="wxComboBox" expanded="0">
                                                 <property name="BottomDockable">1</property>
                                                 <property name="LeftDockable">1</property>
                                                 <property name="RightDockable">1</property>
@@ -622,7 +622,7 @@
                                                 <property name="caption"></property>
                                                 <property name="caption_visible">1</property>
                                                 <property name="center_pane">0</property>
-                                                <property name="choices">&quot;300%&quot; &quot;250%&quot; &quot;200%&quot; &quot;166%&quot; &quot;150%&quot; &quot;133%&quot; &quot;125%&quot; &quot;100%&quot; &quot;66%&quot;</property>
+                                                <property name="choices">&quot;300%&quot; &quot;266%&quot; &quot;233%&quot; &quot;200%&quot; &quot;166%&quot; &quot;133%&quot; &quot;100%&quot; &quot;66%&quot;</property>
                                                 <property name="close_button">1</property>
                                                 <property name="context_help"></property>
                                                 <property name="context_menu">1</property>
@@ -671,11 +671,11 @@
                                                 <event name="OnTextEnter">OnScalingChange</event>
                                             </object>
                                         </object>
-                                        <object class="sizeritem" expanded="1">
+                                        <object class="sizeritem" expanded="0">
                                             <property name="border">5</property>
                                             <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
                                             <property name="proportion">0</property>
-                                            <object class="wxStaticText" expanded="1">
+                                            <object class="wxStaticText" expanded="0">
                                                 <property name="BottomDockable">1</property>
                                                 <property name="LeftDockable">1</property>
                                                 <property name="RightDockable">1</property>
@@ -1094,11 +1094,11 @@
                                         <property name="window_style"></property>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="1">
+                                <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxEXPAND</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxBoxSizer" expanded="1">
+                                    <object class="wxBoxSizer" expanded="0">
                                         <property name="minimum_size"></property>
                                         <property name="name">bSizer488</property>
                                         <property name="orient">wxHORIZONTAL</property>
@@ -1317,7 +1317,7 @@
                 </object>
             </object>
         </object>
-        <object class="Panel" expanded="1">
+        <object class="Panel" expanded="0">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -1341,7 +1341,7 @@
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL</property>
             <event name="OnUpdateUI">OnUpdateUI</event>
-            <object class="wxBoxSizer" expanded="1">
+            <object class="wxBoxSizer" expanded="0">
                 <property name="minimum_size"></property>
                 <property name="name">bSizer63</property>
                 <property name="orient">wxVERTICAL</property>
@@ -1404,11 +1404,11 @@
                         <property name="window_style"></property>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="1">
+                <object class="sizeritem" expanded="0">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">1</property>
-                    <object class="wxSplitterWindow" expanded="1">
+                    <object class="wxSplitterWindow" expanded="0">
                         <property name="BottomDockable">1</property>
                         <property name="LeftDockable">1</property>
                         <property name="RightDockable">1</property>
@@ -1465,8 +1465,8 @@
                         <property name="window_extra_style"></property>
                         <property name="window_name"></property>
                         <property name="window_style"></property>
-                        <object class="splitteritem" expanded="1">
-                            <object class="wxPanel" expanded="1">
+                        <object class="splitteritem" expanded="0">
+                            <object class="wxPanel" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -1517,7 +1517,7 @@
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style">wxTAB_TRAVERSAL</property>
-                                <object class="wxBoxSizer" expanded="1">
+                                <object class="wxBoxSizer" expanded="0">
                                     <property name="minimum_size"></property>
                                     <property name="name">bSizer66</property>
                                     <property name="orient">wxVERTICAL</property>
@@ -2076,8 +2076,8 @@
                                 </object>
                             </object>
                         </object>
-                        <object class="splitteritem" expanded="1">
-                            <object class="wxPanel" expanded="1">
+                        <object class="splitteritem" expanded="0">
+                            <object class="wxPanel" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>

--- a/src/gui/wxformbuilder/ProjectX_picking.fbp
+++ b/src/gui/wxformbuilder/ProjectX_picking.fbp
@@ -3981,7 +3981,7 @@
                                                     <property name="gripper">0</property>
                                                     <property name="hidden">0</property>
                                                     <property name="id">wxID_ANY</property>
-                                                    <property name="label">Left-Click on particles to select/deselect.&#x0A;Ctrl-Left-Click to rubberband area and deselect.&#x0A;Shift-Left-Click to paint area and deselect.&#x0A;Right-Click for zoomed sub-view.</property>
+                                                    <property name="label">Left-Click on particles to select/deselect.&#x0A;Ctrl-Left-Click to rubberband area and deselect.&#x0A;Shift-Left-Click to paint area and deselect.&#x0A;Right-Click for zoomed sub-view.&#x0A;Middle-Mouse-Hold when zoomed to drag across image.</property>
                                                     <property name="markup">0</property>
                                                     <property name="max_size"></property>
                                                     <property name="maximize_button">0</property>


### PR DESCRIPTION
# Description

This branch corrects a bug in PickingBitmapPanel in which the dotted-line deselection box drawn with Ctrl + Left-Click was not being displayed.

It also adds two new features: the ability to upscale images in the PickingBitmapPanel, as well as displaying a scaled sub-map when holding RMB. The up-scaling feature itself also includes the ability to drag across the image to inspect it fully. These features are mostly identical to those in the cisTEM_display program. The idea behind them is simply to improve the visibility of potential particles to the naked eye when performing manual particle selection, especially when monitor resolution may be limited.

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [x] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
