### PR TITLE
Fix #501 - race condition in host memory pinning

### DIFF
--- a/src/gpu/core_extensions/image.cu
+++ b/src/gpu/core_extensions/image.cu
@@ -47,10 +47,10 @@ template void Image::AllocatePageLockedMemory<half_float::half>(int wanted_x_siz
 
 template <typename StorageBaseType>
 void Image::RegisterPageLockedMemory(StorageBaseType* ptr) {
+    wxMutexLocker lock(s_mutexProtectingFFTW); // the mutex will be unlocked when this object is destroyed (when it goes out of scope)
+    MyDebugAssertTrue(lock.IsOk( ), "Mute locking failed");
 
     if ( ! IsMemoryPageLocked(ptr) ) {
-        wxMutexLocker lock(s_mutexProtectingFFTW); // the mutex will be unlocked when this object is destroyed (when it goes out of scope)
-        MyDebugAssertTrue(lock.IsOk( ), "Mute locking failed");
         if constexpr ( std::is_same_v<StorageBaseType, half_float::half> ) {
             cudaErr(cudaHostRegister(real_values_16f, sizeof(StorageBaseType) * real_memory_allocated, cudaHostRegisterDefault));
         }


### PR DESCRIPTION
# Description

Fixes #501 

I think the issue is that the previous location of the mutex in some cases allowed other threads to enter the if statement, when `IsMemoryPageLocked` was still false. This caused `cudaHostRegister` to be called twice.

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
