### PR TITLE
bugfix: DisplayFrame.cpp issues

### DIFF
--- a/src/gui/DisplayFrame.cpp
+++ b/src/gui/DisplayFrame.cpp
@@ -170,7 +170,7 @@ void DisplayFrame::OnOpenTxtClick(wxCommandEvent& event) {
             size_t line_counter = 0;
             while ( valid_file && line_counter < file_to_open->GetLineCount( ) ) {
                 current_line = file_to_open->GetLine(line_counter);
-                valid_file   = LoadSelections(current_line);
+                valid_file   = LoadImageSelections(current_line);
                 line_counter++;
             }
         }
@@ -567,8 +567,8 @@ void DisplayFrame::OnUpdateUI(wxUpdateUIEvent& event) {
 
 bool DisplayFrame::LoadCoords(wxString current_line, long& x, long& y, long& image_number) {
     // Parse the string for x, y, and the image number
-    size_t index_of_whitespace      = current_line.find(' ');
-    size_t prev_whitespace_position = 0;
+    int index_of_whitespace      = current_line.find(' ');
+    int prev_whitespace_position = 0;
     if ( index_of_whitespace == wxNOT_FOUND ) {
         wxMessageDialog wrong_file_format(this, "Cannot open Image Selection text file in Coordinate Selection mode.", "Incorrect File Format", wxOK | wxOK_DEFAULT | wxICON_EXCLAMATION);
         wrong_file_format.ShowModal( );
@@ -595,9 +595,9 @@ bool DisplayFrame::LoadCoords(wxString current_line, long& x, long& y, long& ima
     }
 }
 
-bool DisplayFrame::LoadSelections(wxString current_line) {
+bool DisplayFrame::LoadImageSelections(wxString current_line) {
     // Quick check of file format
-    size_t index_of_whitespace = current_line.find(' ');
+    int index_of_whitespace = current_line.find(' ');
     if ( index_of_whitespace != wxNOT_FOUND ) {
         wxMessageDialog wrong_file_format(this, "Cannot open Coordinate Selection text file in Image Selection mode.", "Incorrect File Format", wxOK | wxOK_DEFAULT | wxICON_EXCLAMATION);
         wrong_file_format.ShowModal( );
@@ -616,6 +616,7 @@ bool DisplayFrame::LoadSelections(wxString current_line) {
     else {
         wxMessageDialog invalid_file_dialog(this, wxString::Format("The file being opened contains selected images that exceed the number of images in the current file. Cannot open the selections.(Images in open file: %i. Image index sought: %li)", cisTEMDisplayPanel->ReturnCurrentPanel( )->ReturnNumberofImages( ), image_number), "Invalid Selection(s) for Current Image(s)", wxOK | wxOK_DEFAULT | wxICON_EXCLAMATION);
         cisTEMDisplayPanel->ClearSelection(false);
+        return false;
     }
 }
 

--- a/src/gui/DisplayFrame.h
+++ b/src/gui/DisplayFrame.h
@@ -51,7 +51,7 @@ class DisplayFrame : public DisplayFrameParent {
     bool     is_fullscreen;
     wxString remember_path;
     bool     LoadCoords(wxString current_line, long& x, long& y, long& image_number);
-    bool     LoadSelections(wxString current_line);
+    bool     LoadImageSelections(wxString current_line);
     void     ClearTextFileFromPanel( );
 };
 


### PR DESCRIPTION
# Description

This solves a few small bugs in relation to the cisTEM_display program:

Refactored the name of `DisplayFrame::LoadSelections` to `DisplayFrame::LoadImageSelections` for clarity. Added return statement to `DisplayFrame::LoadSelections` else statement, converted instances of size_t, an unsigned type, to int, which is signed, as wxNOT_FOUND evaluates to -1. There does remain a couple of instances of size_t, because of `wxTextFile::GetLine(size_t n)`. 

Fixes #498 and #499

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [x] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
