### PR TITLE
feat: ToolTip appears when hovering tabs in display

### DIFF
--- a/src/gui/AbInitio3DPanel.cpp
+++ b/src/gui/AbInitio3DPanel.cpp
@@ -11,7 +11,9 @@ AbInitio3DPanel::AbInitio3DPanel(wxWindow* parent)
 
     SetInfo( );
 
-    ShowOrthDisplayPanel->Initialise(START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR);
+    ShowOrthDisplayPanel->EnableStartWithFourierScaling( );
+    ShowOrthDisplayPanel->EnableDoNotShowStatusBar( );
+    ShowOrthDisplayPanel->Initialise( );
 
     wxSize input_size = InputSizer->GetMinSize( );
     input_size.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);

--- a/src/gui/DisplayPanel.cpp
+++ b/src/gui/DisplayPanel.cpp
@@ -32,7 +32,7 @@ DisplayPanel::DisplayPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, 
     Bind(wxEVT_COMBOBOX, &DisplayPanel::ChangeScaling, this, Toolbar_Scale_Combo_Control);
 }
 
-void DisplayPanel::Initialise(int wanted_style_flags) {
+void DisplayPanel::Initialise( ) {
 
 #include "icons/display_open_icon.cpp"
 #include "icons/display_previous_icon.cpp"
@@ -47,8 +47,6 @@ void DisplayPanel::Initialise(int wanted_style_flags) {
 #include "icons/display_invert_icon.cpp"
 #include "icons/display_high_quality_icon.cpp"
 
-    style_flags = wanted_style_flags;
-
     if ( my_notebook != NULL ) {
         delete my_notebook;
         my_notebook = NULL;
@@ -59,14 +57,12 @@ void DisplayPanel::Initialise(int wanted_style_flags) {
         no_notebook_panel = NULL;
     }
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
-    }
-    else {
+    if ( ! no_notebook ) {
         long flags = wxAUI_NB_SCROLL_BUTTONS | wxAUI_NB_TOP | wxAUI_NB_WINDOWLIST_BUTTON;
 
-        if ( (style_flags & CAN_CLOSE_TABS) == CAN_CLOSE_TABS )
+        if ( can_close_tabs )
             flags |= wxAUI_NB_CLOSE_ON_ACTIVE_TAB;
-        if ( (style_flags & CAN_MOVE_TABS) == CAN_MOVE_TABS )
+        if ( can_close_tabs )
             flags |= wxAUI_NB_TAB_MOVE;
 
         my_notebook = new DisplayNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, flags);
@@ -87,7 +83,7 @@ void DisplayPanel::Initialise(int wanted_style_flags) {
 
     // setup the toolbar..
 
-    if ( (style_flags & CAN_CHANGE_FILE) == CAN_CHANGE_FILE ) {
+    if ( can_change_file ) {
         Toolbar->AddTool(Toolbar_Open, wxT("Open Image file"), wxBITMAP_PNG_FROM_DATA(display_open_icon), wxNullBitmap, wxITEM_NORMAL, wxT("Open Image File"), wxT("Open an new image file in a new tab"));
         Toolbar->AddSeparator( );
         Toolbar->EnableTool(Toolbar_Open, true);
@@ -102,9 +98,7 @@ void DisplayPanel::Initialise(int wanted_style_flags) {
         delete toolbar_number_of_locations_text;
     toolbar_number_of_locations_text = new wxStaticText(Toolbar, wxID_ANY, wxT(""), wxDefaultPosition, wxSize(-1, -1));
 
-    if ( (style_flags & FIRST_LOCATION_ONLY) == FIRST_LOCATION_ONLY ) {
-    }
-    else {
+    if ( ! first_location_only ) {
         Toolbar->AddTool(Toolbar_Previous, wxT("Previous"), wxBITMAP_PNG_FROM_DATA(display_previous_icon), wxNullBitmap, wxITEM_NORMAL, wxT("Previous"), wxT("Move to the previous set of images"));
         Toolbar->EnableTool(Toolbar_Previous, false);
 
@@ -158,7 +152,7 @@ void DisplayPanel::Initialise(int wanted_style_flags) {
 
     Toolbar->AddSeparator( );
 
-    if ( (style_flags & CAN_FFT) == CAN_FFT ) {
+    if ( can_fft ) {
         Toolbar->AddTool(Toolbar_FFT, wxT("FFT"), wxBITMAP_PNG_FROM_DATA(display_fft_icon), wxNullBitmap, wxITEM_CHECK, wxT("FFT Images"), wxT("Fourier Transform Images"));
         Toolbar->EnableTool(Toolbar_FFT, false);
     }
@@ -166,7 +160,7 @@ void DisplayPanel::Initialise(int wanted_style_flags) {
     Toolbar->AddTool(Toolbar_High_Quality, wxT("High Quality Scaling"), wxBITMAP_PNG_FROM_DATA(display_high_quality_icon), wxNullBitmap, wxITEM_CHECK, wxT("Use High Quality Scaling"), wxT("Use High Quality Scaling"));
     Toolbar->EnableTool(Toolbar_High_Quality, false);
 
-    if ( (style_flags & CAN_CHANGE_FILE) == CAN_CHANGE_FILE ) {
+    if ( can_change_file ) {
         Toolbar->AddTool(Toolbar_Refresh, wxT("Refresh"), wxBITMAP_PNG_FROM_DATA(display_refresh_icon), wxNullBitmap, wxITEM_NORMAL, wxT("Refresh"), wxT("Refresh the current view"));
         Toolbar->EnableTool(Toolbar_Refresh, false);
     }
@@ -175,7 +169,7 @@ void DisplayPanel::Initialise(int wanted_style_flags) {
 
     Toolbar->Realize( );
 
-    if ( (style_flags & DO_NOT_SHOW_STATUS_BAR) == DO_NOT_SHOW_STATUS_BAR ) {
+    if ( do_not_show_status_bar ) {
         StatusText->Show(false);
     }
     else
@@ -205,7 +199,7 @@ void DisplayPanel::ChangeLocation(wxCommandEvent& WXUNUSED(event)) {
             current_panel->panel_image_has_correct_greys = false;
             current_panel->ReDrawPanel( );
 
-            if ( (style_flags & KEEP_TABS_LINKED_IF_POSSIBLE) == KEEP_TABS_LINKED_IF_POSSIBLE ) {
+            if ( keep_tabs_linked_if_possible ) {
                 // set all tabs to this scaling
                 long global_location = current_panel->current_location;
 
@@ -280,7 +274,7 @@ void DisplayPanel::ClearActiveTemplateMatchMarker( ) {
 }
 
 void DisplayPanel::CloseAllTabs( ) {
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         // shall i delete the panel
         if ( no_notebook_panel != NULL ) {
             MainSizer->Detach(no_notebook_panel);
@@ -314,7 +308,7 @@ void DisplayPanel::ChangeScaling(wxCommandEvent& WXUNUSED(event)) {
         current_panel->panel_image_has_correct_scale = false;
         current_panel->ReDrawPanel( );
 
-        if ( (style_flags & KEEP_TABS_LINKED_IF_POSSIBLE) == KEEP_TABS_LINKED_IF_POSSIBLE ) {
+        if ( keep_tabs_linked_if_possible ) {
             // set all tabs to this scaling
             double global_scale_factor = current_panel->desired_scale_factor;
 
@@ -465,7 +459,7 @@ void DisplayPanel::OnPrevious(wxCommandEvent& WXUNUSED(event)) {
     current_panel->panel_image_has_correct_greys = false;
     current_panel->ReDrawPanel( );
 
-    if ( (style_flags & KEEP_TABS_LINKED_IF_POSSIBLE) == KEEP_TABS_LINKED_IF_POSSIBLE ) {
+    if ( keep_tabs_linked_if_possible ) {
         // set all tabs to this scaling
         long global_location = current_panel->current_location;
 
@@ -489,7 +483,7 @@ void DisplayPanel::OnPrevious(wxCommandEvent& WXUNUSED(event)) {
 
 DisplayNotebookPanel* DisplayPanel::ReturnCurrentPanel( ) {
     DisplayNotebookPanel* current_panel;
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK )
+    if ( no_notebook )
         current_panel = no_notebook_panel;
     else
         current_panel = (DisplayNotebookPanel*)my_notebook->GetCurrentPage( );
@@ -522,7 +516,7 @@ void DisplayPanel::OnNext(wxCommandEvent& WXUNUSED(event)) {
     current_panel->panel_image_has_correct_greys = false;
     current_panel->ReDrawPanel( );
 
-    if ( (style_flags & KEEP_TABS_LINKED_IF_POSSIBLE) == KEEP_TABS_LINKED_IF_POSSIBLE ) {
+    if ( keep_tabs_linked_if_possible ) {
         // set all tabs to this scaling
         long global_location = current_panel->current_location;
 
@@ -602,7 +596,7 @@ void DisplayPanel::OnRefresh(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void DisplayPanel::ChangeFocusToPanel(void) {
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         if ( no_notebook_panel != NULL )
             no_notebook_panel->SetFocus( );
     }
@@ -617,7 +611,7 @@ void DisplayPanel::ChangeFocusToPanel(void) {
 void DisplayPanel::UpdateToolbar(void) {
     bool blank_toolbar = false;
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         if ( no_notebook_panel == NULL )
             blank_toolbar = true;
     }
@@ -630,13 +624,13 @@ void DisplayPanel::UpdateToolbar(void) {
         toolbar_scale_combo->SetValue(wxT(""));
         toolbar_scale_combo->Disable( );
 
-        if ( (style_flags & CAN_CHANGE_FILE) == CAN_CHANGE_FILE )
+        if ( can_change_file )
             Toolbar->EnableTool(Toolbar_Open, true);
         //Toolbar->EnableTool(Toolbar_Save, false);
         Toolbar->EnableTool(Toolbar_Previous, false);
         Toolbar->EnableTool(Toolbar_Next, false);
         Toolbar->EnableTool(Toolbar_Histogram, false);
-        if ( (style_flags & CAN_CHANGE_FILE) == CAN_CHANGE_FILE )
+        if ( can_change_file )
             Toolbar->EnableTool(Toolbar_Refresh, false);
         toolbar_number_of_locations_text->SetLabel(wxT(""));
         Toolbar->EnableTool(Toolbar_Local, false);
@@ -647,11 +641,11 @@ void DisplayPanel::UpdateToolbar(void) {
 
         Toolbar->EnableTool(Toolbar_High_Quality, false);
 
-        if ( (style_flags & CAN_FFT) == CAN_FFT )
+        if ( can_fft )
             Toolbar->EnableTool(Toolbar_FFT, false);
     }
     else {
-        if ( (style_flags & CAN_CHANGE_FILE) == CAN_CHANGE_FILE )
+        if ( can_change_file )
             Toolbar->EnableTool(Toolbar_Open, true);
 
         // there must be a tab then, so get the selected displayPanel..
@@ -700,11 +694,11 @@ void DisplayPanel::UpdateToolbar(void) {
             Toolbar->EnableTool(Toolbar_Global, true);
             Toolbar->EnableTool(Toolbar_Manual, true);
 
-            if ( (style_flags & CAN_CHANGE_FILE) == CAN_CHANGE_FILE )
+            if ( can_change_file )
                 Toolbar->EnableTool(Toolbar_Refresh, true);
             Toolbar->EnableTool(Toolbar_Histogram, true);
 
-            if ( (style_flags & CAN_FFT) == CAN_FFT ) {
+            if ( can_fft ) {
                 Toolbar->EnableTool(Toolbar_FFT, true);
 
                 if ( current_panel->use_fft ) {
@@ -836,7 +830,7 @@ void DisplayPanel::OpenFile(wxString wanted_filename, wxString wanted_tab_title,
 
     DisplayNotebookPanel* my_panel;
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         if ( no_notebook_panel != NULL )
             no_notebook_panel->Destroy( );
         no_notebook_panel = new DisplayNotebookPanel(this, panel_counter);
@@ -899,9 +893,7 @@ void DisplayPanel::OpenFile(wxString wanted_filename, wxString wanted_tab_title,
         my_panel->current_location = current_image_location;
     }
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
-    }
-    else {
+    if ( ! no_notebook ) {
         my_notebook->Freeze( );
         my_notebook->AddPage(my_panel, wanted_tab_title, false);
         my_notebook->SetPageToolTip(panel_counter - 1, my_panel->filename);
@@ -911,7 +903,7 @@ void DisplayPanel::OpenFile(wxString wanted_filename, wxString wanted_tab_title,
 
     // This was moved here because calling ClearSelection before the panel was added
     // resulted in a crash from a debug assert -- the current page was still null
-    if ( (style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || ReturnCurrentPanel( )->picking_mode == IMAGES_PICK ) {
+    if ( can_select_images || ReturnCurrentPanel( )->image_picking_mode_enabled ) {
         my_panel->image_is_selected = new bool[my_panel->my_file.ReturnNumberOfSlices( ) + 1];
         ClearSelection(false);
     }
@@ -928,11 +920,11 @@ void DisplayPanel::OpenFile(wxString wanted_filename, wxString wanted_tab_title,
     // if there is only one image, then set single image mode to true by default
     if ( is_from_display_program ) {
         if ( my_panel->included_image_numbers.GetCount( ) == 1 ) {
-            my_panel->single_image = true;
-            my_panel->picking_mode = COORDS_PICK;
+            my_panel->single_image               = true;
+            my_panel->image_picking_mode_enabled = false;
         }
         else {
-            my_panel->picking_mode = IMAGES_PICK;
+            my_panel->image_picking_mode_enabled = true;
         }
     }
 
@@ -942,7 +934,7 @@ void DisplayPanel::OpenFile(wxString wanted_filename, wxString wanted_tab_title,
 }
 
 void DisplayPanel::ChangeFileForTabNumber(int wanted_tab_number, wxString wanted_filename, wxString wanted_tab_title, wxArrayLong* wanted_included_image_numbers) {
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         if ( no_notebook_panel == NULL ) {
             OpenFile(wanted_filename, wanted_tab_title, wanted_included_image_numbers);
             return;
@@ -950,7 +942,7 @@ void DisplayPanel::ChangeFileForTabNumber(int wanted_tab_number, wxString wanted
     }
 
     DisplayNotebookPanel* current_panel;
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK )
+    if ( no_notebook )
         current_panel = no_notebook_panel;
     else {
 
@@ -1020,7 +1012,7 @@ void DisplayPanel::ChangeFileForTabNumber(int wanted_tab_number, wxString wanted
         current_panel->image_is_selected = NULL;
     }
 
-    if ( (style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || ReturnCurrentPanel( )->picking_mode == IMAGES_PICK ) {
+    if ( can_select_images || ReturnCurrentPanel( )->image_picking_mode_enabled ) {
         current_panel->image_is_selected = new bool[current_panel->my_file.ReturnNumberOfSlices( ) + 1];
 
         for ( int mycounter = 0; mycounter < current_panel->my_file.ReturnNumberOfSlices( ) + 1; mycounter++ ) {
@@ -1042,9 +1034,7 @@ void DisplayPanel::ChangeFileForTabNumber(int wanted_tab_number, wxString wanted
     current_panel->panel_image = new wxImage(int(current_panel->my_file.ReturnXSize( )), int(current_panel->my_file.ReturnYSize( )));
     current_panel->tab_title   = wanted_tab_title;
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
-    }
-    else {
+    if ( ! no_notebook ) {
 
         my_notebook->SetPageText(wanted_tab_number, wanted_tab_title);
 
@@ -1064,7 +1054,7 @@ void DisplayPanel::ChangeFileForTabNumber(int wanted_tab_number, wxString wanted
 }
 
 void DisplayPanel::ChangeFile(wxString wanted_filename, wxString wanted_tab_title, wxArrayLong* wanted_included_image_numbers) {
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         ChangeFileForTabNumber(-1, wanted_filename, wanted_tab_title, wanted_included_image_numbers);
     }
     else
@@ -1090,7 +1080,7 @@ void DisplayPanel::OpenImage(Image* image_to_view, wxString wanted_tab_title, bo
 
     DisplayNotebookPanel* my_panel;
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         if ( no_notebook_panel != NULL )
             no_notebook_panel->Destroy( );
         no_notebook_panel = new DisplayNotebookPanel(this, panel_counter);
@@ -1123,7 +1113,7 @@ void DisplayPanel::OpenImage(Image* image_to_view, wxString wanted_tab_title, bo
     my_panel->input_is_a_file           = false;
     my_panel->do_i_have_image_ownership = take_ownership;
 
-    if ( (style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES ) {
+    if ( can_select_images ) {
         my_panel->image_is_selected = new bool[image_to_view->logical_z_dimension + 1];
         ClearSelection(false);
     }
@@ -1135,9 +1125,7 @@ void DisplayPanel::OpenImage(Image* image_to_view, wxString wanted_tab_title, bo
     my_panel->panel_image = new wxImage(image_to_view->logical_x_dimension, image_to_view->logical_y_dimension);
     my_panel->tab_title   = wanted_tab_title;
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
-    }
-    else {
+    if ( ! no_notebook ) {
         my_notebook->Freeze( );
         my_notebook->AddPage(my_panel, wanted_tab_title, false);
         my_notebook->Thaw( );
@@ -1157,7 +1145,7 @@ void DisplayPanel::OpenImage(Image* image_to_view, wxString wanted_tab_title, bo
 
     if ( my_panel->included_image_numbers.GetCount( ) == 1 ) {
         //my_panel->single_image = true;
-        //my_panel->picking_mode = COORDS_PICK;
+        //my_panel->image_picking_mode_enabled = COORDS_PICK;
     }
 
     my_panel->ReDrawPanel( );
@@ -1177,7 +1165,7 @@ void DisplayPanel::ChangeImage(Image* image_to_view, wxString wanted_tab_title, 
         }
     }
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+    if ( no_notebook ) {
         if ( no_notebook_panel == NULL ) {
             OpenImage(image_to_view, wanted_tab_title, take_ownership, wanted_included_image_numbers);
             return;
@@ -1248,7 +1236,7 @@ void DisplayPanel::ChangeImage(Image* image_to_view, wxString wanted_tab_title, 
     }
 
     // Image or stack just opened; set all images as not selected
-    if ( (style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || ReturnCurrentPanel( )->picking_mode == IMAGES_PICK ) {
+    if ( can_select_images || ReturnCurrentPanel( )->image_picking_mode_enabled ) {
         current_panel->image_is_selected = new bool[image_to_view->logical_z_dimension + 1];
         for ( int mycounter = 0; mycounter < image_to_view->logical_z_dimension + 1; mycounter++ ) {
             current_panel->image_is_selected[mycounter] = false;
@@ -1269,9 +1257,7 @@ void DisplayPanel::ChangeImage(Image* image_to_view, wxString wanted_tab_title, 
     current_panel->panel_image = new wxImage(image_to_view->logical_x_dimension, image_to_view->logical_y_dimension);
     current_panel->tab_title   = wanted_tab_title;
 
-    if ( (style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
-    }
-    else {
+    if ( ! no_notebook ) {
         my_notebook->SetPageText(my_notebook->GetSelection( ), wanted_tab_title);
     }
 
@@ -1288,6 +1274,83 @@ void DisplayPanel::ChangeImage(Image* image_to_view, wxString wanted_tab_title, 
     //notebook->SetFocus();
     ChangeFocusToPanel( );
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+// SETTERS for panel features: these should be called only once prior to initialise wherever the panel
+// is used to convert them from false to true However, this implementation would technically allow
+// flipping them back, which may not be desired...
+///////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void DisplayPanel::EnableCanChangeFile( ) { can_change_file = true; }
+
+void DisplayPanel::EnableCanCloseTabs( ) { can_close_tabs = true; }
+
+void DisplayPanel::EnableCanFFT( ) { can_fft = true; }
+
+void DisplayPanel::EnableStartWithInvertedContrast( ) { start_with_inverted_contrast = true; }
+
+void DisplayPanel::EnableStartWithAutoContrast( ) { start_with_auto_contrast = true; }
+
+void DisplayPanel::EnableNoNotebook( ) { no_notebook = true; }
+
+void DisplayPanel::EnableFirstLocationOnly( ) { first_location_only = true; }
+
+void DisplayPanel::EnableStartWithFourierScaling( ) { start_with_fourier_scaling = true; }
+
+void DisplayPanel::EnableDoNotShowStatusBar( ) { do_not_show_status_bar = true; }
+
+void DisplayPanel::EnableCanSelectImages( ) { can_select_images = true; }
+
+void DisplayPanel::EnableNoPopup( ) { no_popup = true; }
+
+void DisplayPanel::EnableStartWithNoLabel( ) { start_with_no_label = true; }
+
+void DisplayPanel::EnableSkipLeftclickToParent( ) { skip_leftclick_to_parent = true; }
+
+void DisplayPanel::EnableCanMoveTabs( ) { can_move_tabs = true; }
+
+void DisplayPanel::EnableDrawImageSeparator( ) { draw_image_separator = true; }
+
+void DisplayPanel::EnableKeepTabsLinked( ) { keep_tabs_linked_if_possible = true; }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+// GETTERS; as of now, many of these may not be necessary as the features are set and only used within
+// the class itself. But, there are a few instances the values are needed outside of the class; because
+// of this, it is better to make these now so they can be used if new features are added that require
+// access but don't need direct access.
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool DisplayPanel::GetCanChangeFile( ) { return can_change_file; }
+
+bool DisplayPanel::GetCanCloseTabs( ) { return can_close_tabs; }
+
+bool DisplayPanel::GetCanFFT( ) { return can_fft; }
+
+bool DisplayPanel::GetStartWithInvertedContrast( ) { return start_with_inverted_contrast; }
+
+bool DisplayPanel::GetStartWithAutoContrast( ) { return start_with_auto_contrast; }
+
+bool DisplayPanel::GetNoNotebook( ) { return no_notebook; }
+
+bool DisplayPanel::GetFirstLocationOnly( ) { return first_location_only; }
+
+bool DisplayPanel::GetStartWithFourierScaling( ) { return start_with_fourier_scaling; }
+
+bool DisplayPanel::GetDoNotShowStatusBar( ) { return do_not_show_status_bar; }
+
+bool DisplayPanel::GetCanSelectImages( ) { return can_select_images; }
+
+bool DisplayPanel::GetNoPopup( ) { return no_popup; }
+
+bool DisplayPanel::GetStartWithNoLabel( ) { return start_with_no_label; }
+
+bool DisplayPanel::GetSkipLeftclickToParent( ) { return skip_leftclick_to_parent; }
+
+bool DisplayPanel::GetCanMoveTabs( ) { return can_move_tabs; }
+
+bool DisplayPanel::GetDrawImageSeparator( ) { return draw_image_separator; }
+
+bool DisplayPanel::GetKeepTabsLinked( ) { return keep_tabs_linked_if_possible; }
 
 DisplayNotebook::DisplayNotebook(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style)
     : wxAuiNotebook(parent, id, pos, size, style) {
@@ -1378,19 +1441,19 @@ DisplayNotebookPanel::DisplayNotebookPanel(wxWindow* parent, wxWindowID id, cons
 
     use_unscaled_image_for_popup = false;
 
-    if ( (parent_display_panel->style_flags & FIRST_LOCATION_ONLY) == FIRST_LOCATION_ONLY || (parent_display_panel->style_flags & START_WITH_NO_LABEL) == START_WITH_NO_LABEL ) {
+    if ( parent_display_panel->GetFirstLocationOnly( ) || parent_display_panel->GetStartWithNoLabel( ) ) {
         show_label = false;
     }
     else
         show_label = true;
 
-    if ( (parent_display_panel->style_flags & START_WITH_INVERTED_CONTRAST) == START_WITH_INVERTED_CONTRAST ) {
+    if ( parent_display_panel->start_with_inverted_contrast ) {
         invert_contrast = true;
     }
     else
         invert_contrast = false;
 
-    if ( (parent_display_panel->style_flags & START_WITH_FOURIER_SCALING) == START_WITH_FOURIER_SCALING ) {
+    if ( parent_display_panel->start_with_fourier_scaling ) {
         use_fourier_scaling = true;
     }
     else
@@ -1425,7 +1488,7 @@ DisplayNotebookPanel::DisplayNotebookPanel(wxWindow* parent, wxWindowID id, cons
     manual_low_grey      = 0.;
     manual_high_grey     = 0.;
 
-    if ( (parent_display_panel->style_flags & START_WITH_AUTO_CONTRAST) == START_WITH_AUTO_CONTRAST )
+    if ( parent_display_panel->start_with_auto_contrast )
         grey_values_decided_by = AUTO_GREYS;
     else
         grey_values_decided_by = LOCAL_GREYS;
@@ -1441,10 +1504,12 @@ DisplayNotebookPanel::DisplayNotebookPanel(wxWindow* parent, wxWindowID id, cons
     integrate_box_y_pos = -1;
     integrated_value    = -1;
 
-    picking_mode             = IMAGES_PICK; // Do this by default, change when creating the frame.
-    have_txt_filename        = false;
-    txt_is_saved             = false;
-    selected_filament_number = 1;
+    // This is specific to the display program, and differentiates whether the user's left click will
+    // Select images or coordinates
+    image_picking_mode_enabled = true;
+    have_txt_filename          = false;
+    txt_is_saved               = false;
+    selected_filament_number   = 1;
 
     int window_x_size;
     int window_y_size;
@@ -1506,14 +1571,14 @@ void DisplayNotebookPanel::UpdateImageStatusInfo(int x_pos, int y_pos) {
             StatusText += wxT(", Value=") + wxString::Format(wxT("%f"), raw_pixel_value);
 
             //if (selected_distance != 0 && show_selection_distances ) StatusText += wxT(", Dist=") + wxString::Format(wxT("%f"), selected_distance);
-            //if (picking_mode == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT(", Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
+            //if (image_picking_mode_enabled == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT(", Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
             parent_display_panel->StatusText->SetLabel(StatusText);
         }
         else {
             wxString StatusText = wxT("");
 
             //if (selected_distance != 0 && show_selection_distances ) StatusText += wxT("Dist=") + wxString::Format(wxT("%f"), selected_distance);
-            //	if (picking_mode == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT("Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
+            //	if (image_picking_mode_enabled == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT("Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
             parent_display_panel->StatusText->SetLabel(StatusText);
         }
     }
@@ -1550,14 +1615,14 @@ void DisplayNotebookPanel::UpdateImageStatusInfo(int x_pos, int y_pos) {
                 StatusText += wxT(", Value=") + wxString::Format(wxT("%f"), raw_pixel_value);
 
                 //	if (selected_distance != 0 && show_selection_distances ) StatusText += wxT(", Dist=") + wxString::Format(wxT("%f"), selected_distance);
-                //	if (picking_mode == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT(", Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
+                //	if (image_picking_mode_enabled == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT(", Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
                 parent_display_panel->StatusText->SetLabel(StatusText);
             }
             else {
                 wxString StatusText = wxT("");
 
                 //	if (selected_distance != 0 && show_selection_distances ) StatusText += wxT("Dist=") + wxString::Format(wxT("%f"), selected_distance);
-                //	if (picking_mode == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT("Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
+                //	if (image_picking_mode_enabled == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT("Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
                 parent_display_panel->StatusText->SetLabel(StatusText);
             }
         }
@@ -1565,7 +1630,7 @@ void DisplayNotebookPanel::UpdateImageStatusInfo(int x_pos, int y_pos) {
             wxString StatusText = wxT("");
 
             // 		if (selected_distance != 0 && show_selection_distances ) StatusText += wxT("Dist=") + wxString::Format(wxT("%f"), selected_distance);
-            // 		if (picking_mode == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT(" Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
+            // 		if (image_picking_mode_enabled == INTEGRATE_PICK && integrate_box_x_pos != -1 && integrate_box_y_pos != -1) StatusText += wxT(" Integrated Value =") + wxString::Format(wxT("%f"), integrated_value);
             parent_display_panel->StatusText->SetLabel(StatusText);
         }
     }
@@ -1577,7 +1642,7 @@ void DisplayNotebookPanel::OnKeyDown(wxKeyEvent& event) {
     wxCommandEvent null_event;
 
     if ( current_keycode == WXK_LEFT ) {
-        if ( (parent_display_panel->style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+        if ( parent_display_panel->no_notebook ) {
         }
         else {
             int current_page = parent_display_panel->my_notebook->GetSelection( );
@@ -1588,7 +1653,7 @@ void DisplayNotebookPanel::OnKeyDown(wxKeyEvent& event) {
         }
     }
     else if ( current_keycode == WXK_RIGHT ) {
-        if ( (parent_display_panel->style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+        if ( parent_display_panel->no_notebook ) {
         }
         else {
             int current_page = parent_display_panel->my_notebook->GetSelection( );
@@ -1712,7 +1777,7 @@ void DisplayNotebookPanel::OnRightDown(wxMouseEvent& event) {
 
     event.GetPosition(&x_pos, &y_pos);
 
-    if ( (parent_display_panel->style_flags & NO_POPUP) == NO_POPUP ) {
+    if ( parent_display_panel->no_popup ) {
         // work out which is the selected image, and put it into the event..
 
         int image_x_coord;
@@ -1787,7 +1852,7 @@ void DisplayNotebookPanel::OnRightDown(wxMouseEvent& event) {
 }
 
 void DisplayNotebookPanel::SetImageSelected(long wanted_image, bool refresh) {
-    MyDebugAssertTrue((parent_display_panel->style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || picking_mode == IMAGES_PICK, "Trying to select images, but selection style flag not set");
+    MyDebugAssertTrue(parent_display_panel->can_select_images || image_picking_mode_enabled, "Trying to select images, but selection style flag not set");
     MyDebugAssertTrue(wanted_image > 0 && wanted_image <= ReturnNumberofImages( ), "Trying to select an image that doesn't exist (%li)", wanted_image);
 
     if ( ! image_is_selected[wanted_image] )
@@ -1801,7 +1866,7 @@ void DisplayNotebookPanel::SetImageSelected(long wanted_image, bool refresh) {
 }
 
 void DisplayNotebookPanel::SetImageNotSelected(long wanted_image, bool refresh) {
-    MyDebugAssertTrue((parent_display_panel->style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || picking_mode == IMAGES_PICK, "Trying to select images, but selection style flag not set");
+    MyDebugAssertTrue(parent_display_panel->can_select_images || image_picking_mode_enabled, "Trying to select images, but selection style flag not set");
     MyDebugAssertTrue(wanted_image > 0 && wanted_image <= ReturnNumberofImages( ), "Trying to select an image that doesn't exist (%li)", wanted_image);
 
     if ( image_is_selected[wanted_image] )
@@ -1815,7 +1880,7 @@ void DisplayNotebookPanel::SetImageNotSelected(long wanted_image, bool refresh) 
 }
 
 void DisplayNotebookPanel::ToggleImageSelected(long wanted_image, bool refresh) {
-    MyDebugAssertTrue((parent_display_panel->style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || picking_mode == IMAGES_PICK, "Trying to select images, but selection style flag not set");
+    MyDebugAssertTrue(parent_display_panel->can_select_images || image_picking_mode_enabled, "Trying to select images, but selection style flag not set");
     MyDebugAssertTrue(wanted_image > 0 && wanted_image <= ReturnNumberofImages( ), "Trying to select an image that doesn't exist (%li)", wanted_image);
 
     if ( image_is_selected[wanted_image] ) {
@@ -1834,7 +1899,7 @@ void DisplayNotebookPanel::ToggleImageSelected(long wanted_image, bool refresh) 
 }
 
 void DisplayNotebookPanel::ClearSelection(bool refresh) {
-    MyDebugAssertTrue((parent_display_panel->style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || picking_mode == IMAGES_PICK, "Trying to clear selection, but selection style flag not set");
+    MyDebugAssertTrue(parent_display_panel->can_select_images || image_picking_mode_enabled, "Trying to clear selection, but selection style flag not set");
 
     for ( long mycounter = 0; mycounter < ReturnNumberofImages( ) + 1; mycounter++ ) {
         image_is_selected[mycounter] = false;
@@ -1885,7 +1950,7 @@ void DisplayNotebookPanel::OnLeftDown(wxMouseEvent& event) {
         current_y_pos = (y_pos - (current_y_size * image_y_coord)) / actual_scale_factor;
     }
 
-    if ( (parent_display_panel->style_flags & SKIP_LEFTCLICK_TO_PARENT) == SKIP_LEFTCLICK_TO_PARENT ) {
+    if ( parent_display_panel->skip_leftclick_to_parent ) {
         if ( x_pos < max_x && y_pos < max_y ) {
             event.SetId(current_image);
         }
@@ -1899,7 +1964,7 @@ void DisplayNotebookPanel::OnLeftDown(wxMouseEvent& event) {
 
     // check if the CTRL key is down, if so we want to make a selection box...
 
-    /*if ( event.ControlDown( )  && picking_mode == COORDS_PICK ) // we want to draw a selection box..
+    /*if ( event.ControlDown( )  && image_picking_mode_enabled == COORDS_PICK ) // we want to draw a selection box..
     {
         drawing_selection_square = true;
 
@@ -1919,7 +1984,7 @@ void DisplayNotebookPanel::OnLeftDown(wxMouseEvent& event) {
 
         if ( current_x_pos < ReturnImageXSize( ) && current_x_pos >= 0 && current_y_pos < ReturnImageYSize( ) && current_y_pos >= 0 ) {
             if ( current_image <= ReturnNumberofImages( ) ) {
-                if ( picking_mode == IMAGES_PICK ) {
+                if ( image_picking_mode_enabled ) {
                     if ( image_is_selected[current_image] ) {
                         image_is_selected[current_image] = false;
                         number_of_selections--;
@@ -1931,7 +1996,7 @@ void DisplayNotebookPanel::OnLeftDown(wxMouseEvent& event) {
 
                     parent_display_panel->SetTabNameUnsaved( );
                 }
-                else if ( picking_mode == COORDS_PICK ) {
+                else if ( ! image_picking_mode_enabled ) {
                     coord_tracker->ToggleCoord(current_image, current_x_pos, current_y_pos);
                     parent_display_panel->SetTabNameUnsaved( );
                 }
@@ -1943,13 +2008,13 @@ void DisplayNotebookPanel::OnLeftDown(wxMouseEvent& event) {
     else if ( x_pos < max_x && y_pos < max_y ) {
         // perform the relevant action..
         if ( current_image <= ReturnNumberofImages( ) ) {
-            if ( (parent_display_panel->style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || (parent_display_panel->is_from_display_program && picking_mode == IMAGES_PICK) ) {
+            if ( parent_display_panel->can_select_images || (parent_display_panel->is_from_display_program && image_picking_mode_enabled) ) {
                 ToggleImageSelected(current_image, false);
                 parent_display_panel->SetTabNameUnsaved( );
             }
 
             // We must be in coords mode
-            else if ( parent_display_panel->is_from_display_program && picking_mode == COORDS_PICK ) {
+            else if ( parent_display_panel->is_from_display_program && ! image_picking_mode_enabled ) {
                 coord_tracker->ToggleCoord(current_image, current_x_pos, current_y_pos);
                 parent_display_panel->SetTabNameUnsaved( );
             }
@@ -2133,7 +2198,7 @@ bool DisplayNotebookPanel::CheckFileStillValid( ) {
         else {
             wxMessageBox(wxT("The current file is no longer accessible, or has changed number/size/type!!"), wxT("Error!!"), wxOK | wxICON_INFORMATION, this);
 
-            if ( (parent_display_panel->style_flags & NO_NOTEBOOK) == NO_NOTEBOOK ) {
+            if ( parent_display_panel->no_notebook ) {
                 // delete panel?
             }
             else {
@@ -2488,7 +2553,7 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
                                 address = (scaled_image_memory_buffer[image_counter].logical_y_dimension - 1 - j) * (scaled_image_memory_buffer[image_counter].logical_x_dimension + scaled_image_memory_buffer[image_counter].padding_jump_value);
 
                                 for ( i = 0; i < scaled_image_memory_buffer[image_counter].logical_x_dimension; i++ ) {
-                                    if ( (parent_display_panel->style_flags & DRAW_IMAGE_SEPARATOR) == DRAW_IMAGE_SEPARATOR && (j == 0 || j == scaled_image_memory_buffer[image_counter].logical_y_dimension - 1 || i == 0 || i == scaled_image_memory_buffer[image_counter].logical_x_dimension - 1) ) {
+                                    if ( parent_display_panel->draw_image_separator && (j == 0 || j == scaled_image_memory_buffer[image_counter].logical_y_dimension - 1 || i == 0 || i == scaled_image_memory_buffer[image_counter].logical_x_dimension - 1) ) {
                                         image_data[red_counter]   = 0;
                                         image_data[green_counter] = 0;
                                         image_data[blue_counter]  = 0;
@@ -2523,7 +2588,7 @@ void DisplayNotebookPanel::ReDrawPanel(void) {
                                 address = (image_memory_buffer[image_counter].logical_y_dimension - 1 - j) * (image_memory_buffer[image_counter].logical_x_dimension + image_memory_buffer[image_counter].padding_jump_value);
 
                                 for ( i = 0; i < image_memory_buffer[image_counter].logical_x_dimension; i++ ) {
-                                    if ( (parent_display_panel->style_flags & DRAW_IMAGE_SEPARATOR) == DRAW_IMAGE_SEPARATOR && (float(j) <= 1.0f / desired_scale_factor || float(j) >= image_memory_buffer[image_counter].logical_y_dimension - 1.0f / desired_scale_factor || float(i) <= 1.0f / desired_scale_factor || float(i) >= image_memory_buffer[image_counter].logical_x_dimension - 1.0f / desired_scale_factor) ) {
+                                    if ( parent_display_panel->draw_image_separator && (float(j) <= 1.0f / desired_scale_factor || float(j) >= image_memory_buffer[image_counter].logical_y_dimension - 1.0f / desired_scale_factor || float(i) <= 1.0f / desired_scale_factor || float(i) >= image_memory_buffer[image_counter].logical_x_dimension - 1.0f / desired_scale_factor) ) {
                                         image_data[red_counter]   = 0;
                                         image_data[green_counter] = 0;
                                         image_data[blue_counter]  = 0;
@@ -2742,9 +2807,9 @@ void DisplayNotebookPanel::OnPaint(wxPaintEvent& evt) {
         if ( ! suspend_overlays ) {
 
             dc.SetPen(*wxRED);
-            if ( picking_mode == IMAGES_PICK )
+            if ( image_picking_mode_enabled )
                 dc.SetBrush(wxBrush(*wxRED, wxTRANSPARENT));
-            else if ( picking_mode == COORDS_PICK ) {
+            else {
                 dc.SetBrush(wxBrush(*wxRED, wxSOLID));
             }
 
@@ -2753,7 +2818,7 @@ void DisplayNotebookPanel::OnPaint(wxPaintEvent& evt) {
             for ( int y = 0; y < images_in_y; y++ ) {
                 for ( int x = 0; x < images_in_x; x++ ) {
                     if ( counter <= ReturnNumberofImages( ) ) {
-                        if ( (parent_display_panel->style_flags & CAN_SELECT_IMAGES) == CAN_SELECT_IMAGES || (parent_display_panel->is_from_display_program && picking_mode == IMAGES_PICK) ) {
+                        if ( parent_display_panel->can_select_images || (parent_display_panel->is_from_display_program && image_picking_mode_enabled) ) {
                             if ( image_is_selected[counter] ) {
 
                                 // draw a rectangle around the image..
@@ -2762,7 +2827,7 @@ void DisplayNotebookPanel::OnPaint(wxPaintEvent& evt) {
                         }
 
                         // Otherwise, we're picking coords (and therefore in display program)
-                        else if ( parent_display_panel->is_from_display_program && parent_display_panel->ReturnCurrentPanel( )->picking_mode == COORDS_PICK ) {
+                        else if ( parent_display_panel->is_from_display_program && ! parent_display_panel->ReturnCurrentPanel( )->image_picking_mode_enabled ) {
 
                             // find all the coordinates for this image..
                             for ( coord_counter = 0; coord_counter < coord_tracker->number_of_coords; coord_counter++ ) {
@@ -3794,7 +3859,7 @@ void DisplayManualDialog::OnHighChange(wxCommandEvent& WXUNUSED(event)) {
 
 void DisplayPanel::SetTabNameUnsaved( ) {
     // Add this because we only want to update tab names if there are tabs
-    if ( ! ((style_flags & NO_NOTEBOOK) == NO_NOTEBOOK) ) {
+    if ( ! no_notebook ) {
         ReturnCurrentPanel( )->txt_is_saved = false;
         RefreshTabName( );
     }
@@ -3802,7 +3867,7 @@ void DisplayPanel::SetTabNameUnsaved( ) {
 
 void DisplayPanel::SetTabNameSaved( ) {
     // Add this because we only want to update tab names if there are tabs
-    if ( ! ((style_flags & NO_NOTEBOOK) == NO_NOTEBOOK) ) {
+    if ( ! no_notebook ) {
         ReturnCurrentPanel( )->txt_is_saved = true;
         RefreshTabName( );
     }
@@ -3810,7 +3875,7 @@ void DisplayPanel::SetTabNameSaved( ) {
 
 void DisplayPanel::RefreshTabName( ) {
     // Add this because we only want to update tab names if there are tabs
-    if ( ! ((style_flags & NO_NOTEBOOK) == NO_NOTEBOOK) ) {
+    if ( ! no_notebook ) {
         int selected_tab = my_notebook->GetSelection( );
 
         wxString tab_text;

--- a/src/gui/DisplayPanel.h
+++ b/src/gui/DisplayPanel.h
@@ -4,31 +4,10 @@
 #include <wx/popupwin.h>
 #include <wx/aui/auibook.h>
 
-#define CAN_CHANGE_FILE 1 // 2^0, bit 0
-#define CAN_CLOSE_TABS 2 // 2^1, bit 1
-#define CAN_FFT 4 // 2^2, bit 2
-#define START_WITH_INVERTED_CONTRAST 8
-#define START_WITH_AUTO_CONTRAST 16
-#define NO_NOTEBOOK 32
-#define FIRST_LOCATION_ONLY 64
-#define START_WITH_FOURIER_SCALING 128
-#define DO_NOT_SHOW_STATUS_BAR 256
-#define CAN_SELECT_IMAGES 1024
-#define NO_POPUP 2048
-#define START_WITH_NO_LABEL 4096
-#define SKIP_LEFTCLICK_TO_PARENT 8192
-#define CAN_MOVE_TABS 16384
-#define DRAW_IMAGE_SEPARATOR 32768
-#define KEEP_TABS_LINKED_IF_POSSIBLE 65536
-
 #define LOCAL_GREYS 0
 #define GLOBAL_GREYS 1
 #define MANUAL_GREYS 2
 #define AUTO_GREYS 3
-
-// These are only used for the cisTEM_display program
-#define COORDS_PICK 0
-#define IMAGES_PICK 1
 
 class DisplayPopup;
 class DisplayNotebook;
@@ -65,8 +44,6 @@ class
     friend class DisplayNotebookPanel;
 
   protected:
-    int style_flags;
-
     wxTextCtrl*   toolbar_location_text;
     wxStaticText* toolbar_number_of_locations_text;
     wxComboBox*   toolbar_scale_combo;
@@ -83,7 +60,7 @@ class
 
     DisplayPanel(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxTAB_TRAVERSAL);
 
-    void Initialise(int style_flags = 0);
+    void Initialise( );
 
     void OpenFile(wxString wanted_filename, wxString wanted_tab_title, wxArrayLong* wanted_included_image_numbers = NULL, bool keep_scale_and_location_if_possible = false, bool force_local_survey = false);
     void ChangeFile(wxString wanted_filename, wxString wanted_tab_title, wxArrayLong* wanted_included_image_numbers = NULL);
@@ -98,7 +75,6 @@ class
 
     void UpdateToolbar( );
     void ChangeFocusToPanel(void);
-    void ReDrawCurrentPanel( );
 
     void SetSelectionSquareLocation(long wanted_location);
 
@@ -126,13 +102,67 @@ class
     void ChangeLocation(wxCommandEvent& event);
     void ChangeScaling(wxCommandEvent& event);
     void OnHighQuality(wxCommandEvent& event);
-    void OnMiddleUp(wxCommandEvent& event);
     void OnRefresh(wxCommandEvent& event);
 
     DisplayNotebookPanel* ReturnCurrentPanel( );
 
     void Clear( );
     void CloseAllTabs( );
+
+    // Setters for feature bool values
+    void EnableCanChangeFile( );
+    void EnableCanCloseTabs( );
+    void EnableCanFFT( );
+    void EnableStartWithInvertedContrast( );
+    void EnableStartWithAutoContrast( );
+    void EnableNoNotebook( );
+    void EnableFirstLocationOnly( );
+    void EnableStartWithFourierScaling( );
+    void EnableDoNotShowStatusBar( );
+    void EnableCanSelectImages( );
+    void EnableNoPopup( );
+    void EnableStartWithNoLabel( );
+    void EnableSkipLeftclickToParent( );
+    void EnableCanMoveTabs( );
+    void EnableDrawImageSeparator( );
+    void EnableKeepTabsLinked( );
+
+    // For encapsulation; not technically in use at the moment, but included in the event
+    // they ever become needed
+    bool GetCanChangeFile( );
+    bool GetCanCloseTabs( );
+    bool GetCanFFT( );
+    bool GetStartWithInvertedContrast( );
+    bool GetStartWithAutoContrast( );
+    bool GetNoNotebook( );
+    bool GetFirstLocationOnly( );
+    bool GetStartWithFourierScaling( );
+    bool GetDoNotShowStatusBar( );
+    bool GetCanSelectImages( );
+    bool GetNoPopup( );
+    bool GetStartWithNoLabel( );
+    bool GetSkipLeftclickToParent( );
+    bool GetCanMoveTabs( );
+    bool GetDrawImageSeparator( );
+    bool GetKeepTabsLinked( );
+
+  private:
+    bool can_change_file              = false;
+    bool can_close_tabs               = false;
+    bool can_fft                      = false;
+    bool start_with_inverted_contrast = false;
+    bool start_with_auto_contrast     = false;
+    bool no_notebook                  = false;
+    bool first_location_only          = false;
+    bool start_with_fourier_scaling   = false;
+    bool do_not_show_status_bar       = false;
+    bool can_select_images            = false;
+    bool no_popup                     = false;
+    bool start_with_no_label          = false;
+    bool skip_leftclick_to_parent     = false;
+    bool can_move_tabs                = false;
+    bool draw_image_separator         = false;
+    bool keep_tabs_linked_if_possible = false;
 };
 
 class
@@ -347,8 +377,8 @@ class
     long selected_filament_number;
     bool only_show_selected_filament;
 
-    int label_mode;
-    int picking_mode;
+    int  label_mode;
+    bool image_picking_mode_enabled;
 
     wxBitmap panel_bitmap;
 

--- a/src/gui/DisplayRefinementResultsPanel.cpp
+++ b/src/gui/DisplayRefinementResultsPanel.cpp
@@ -2,8 +2,9 @@
 
 DisplayRefinementResultsPanel::DisplayRefinementResultsPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style, const wxString& name)
     : DisplayRefinementResultsPanelParent(parent, id, pos, size, style) {
-
-    ShowOrthDisplayPanel->Initialise(START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR);
+    ShowOrthDisplayPanel->EnableStartWithFourierScaling( );
+    ShowOrthDisplayPanel->EnableDoNotShowStatusBar( );
+    ShowOrthDisplayPanel->Initialise( );
 }
 
 void DisplayRefinementResultsPanel::Clear( ) {
@@ -15,7 +16,9 @@ void DisplayRefinementResultsPanel::Clear( ) {
 DisplayCTFRefinementResultsPanel::DisplayCTFRefinementResultsPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style, const wxString& name)
     : DisplayCTFRefinementResultsPanelParent(parent, id, pos, size, style) {
 
-    ShowOrthDisplayPanel->Initialise(START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR);
+    ShowOrthDisplayPanel->EnableStartWithFourierScaling( );
+    ShowOrthDisplayPanel->EnableDoNotShowStatusBar( );
+    ShowOrthDisplayPanel->Initialise( );
 }
 
 void DisplayCTFRefinementResultsPanel::Clear( ) {

--- a/src/gui/MyRefine2DPanel.cpp
+++ b/src/gui/MyRefine2DPanel.cpp
@@ -21,7 +21,10 @@ MyRefine2DPanel::MyRefine2DPanel(wxWindow* parent)
 
     my_classification_manager.SetParent(this);
 
-    ResultDisplayPanel->Initialise(CAN_FFT | START_WITH_FOURIER_SCALING | KEEP_TABS_LINKED_IF_POSSIBLE);
+    ResultDisplayPanel->EnableCanFFT( );
+    ResultDisplayPanel->EnableStartWithFourierScaling( );
+    ResultDisplayPanel->EnableKeepTabsLinked( );
+    ResultDisplayPanel->Initialise( );
 
     RefinementPackageComboBox->AssetComboBox->Bind(wxEVT_COMMAND_COMBOBOX_SELECTED, &MyRefine2DPanel::OnRefinementPackageComboBox, this);
     InputParametersComboBox->AssetComboBox->Bind(wxEVT_COMMAND_COMBOBOX_SELECTED, &MyRefine2DPanel::OnInputParametersComboBox, this);

--- a/src/gui/MyRefinementResultsPanel.cpp
+++ b/src/gui/MyRefinementResultsPanel.cpp
@@ -15,7 +15,9 @@ MyRefinementResultsPanel::MyRefinementResultsPanel(wxWindow* parent)
     currently_displayed_refinement = NULL;
     buffered_full_refinement       = NULL;
 
-    OrthPanel->Initialise(START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR);
+    OrthPanel->EnableStartWithFourierScaling( );
+    OrthPanel->EnableDoNotShowStatusBar( );
+    OrthPanel->Initialise( );
     OrthPanel->my_notebook->Bind(wxEVT_AUINOTEBOOK_PAGE_CHANGED, &MyRefinementResultsPanel::OnDisplayTabChange, this);
 
     RefinementPackageComboBox->AssetComboBox->Bind(wxEVT_COMMAND_COMBOBOX_SELECTED, &MyRefinementResultsPanel::OnRefinementPackageComboBox, this);

--- a/src/gui/Refine2DResultsPanel.cpp
+++ b/src/gui/Refine2DResultsPanel.cpp
@@ -6,9 +6,24 @@ Refine2DResultsPanel::Refine2DResultsPanel(wxWindow* parent, wxWindowID id, cons
     : Refine2DResultsPanelParent(parent, id, pos, size, style) {
 #include "icons/add_file_icon.cpp"
 #include "icons/delete_file_icon.cpp"
+    ClassumDisplayPanel->EnableCanFFT( );
+    ClassumDisplayPanel->EnableNoNotebook( );
+    ClassumDisplayPanel->EnableCanSelectImages( );
+    ClassumDisplayPanel->EnableNoPopup( );
+    ClassumDisplayPanel->EnableStartWithFourierScaling( );
+    ClassumDisplayPanel->EnableSkipLeftclickToParent( );
+    ClassumDisplayPanel->EnableDoNotShowStatusBar( );
+    ClassumDisplayPanel->Initialise( );
 
-    ClassumDisplayPanel->Initialise(CAN_FFT | NO_NOTEBOOK | CAN_SELECT_IMAGES | NO_POPUP | START_WITH_FOURIER_SCALING | SKIP_LEFTCLICK_TO_PARENT | DO_NOT_SHOW_STATUS_BAR);
-    ParticleDisplayPanel->Initialise(CAN_FFT | START_WITH_INVERTED_CONTRAST | START_WITH_AUTO_CONTRAST | NO_NOTEBOOK | START_WITH_NO_LABEL | START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR | DRAW_IMAGE_SEPARATOR);
+    ParticleDisplayPanel->EnableCanFFT( );
+    ParticleDisplayPanel->EnableStartWithInvertedContrast( );
+    ParticleDisplayPanel->EnableStartWithAutoContrast( );
+    ParticleDisplayPanel->EnableNoNotebook( );
+    ParticleDisplayPanel->EnableStartWithNoLabel( );
+    ParticleDisplayPanel->EnableStartWithFourierScaling( );
+    ParticleDisplayPanel->EnableDoNotShowStatusBar( );
+    ParticleDisplayPanel->EnableDrawImageSeparator( );
+    ParticleDisplayPanel->Initialise( );
     selected_class                      = 1;
     refinement_package_combo_is_dirty   = false;
     input_params_combo_is_dirty         = false;

--- a/src/gui/Sharpen3DPanel.cpp
+++ b/src/gui/Sharpen3DPanel.cpp
@@ -5,7 +5,11 @@ extern MyRefinementPackageAssetPanel* refinement_package_asset_panel;
 
 Sharpen3DPanel::Sharpen3DPanel(wxWindow* parent)
     : Sharpen3DPanelParent(parent) {
-    ResultDisplayPanel->Initialise(START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR | START_WITH_NO_LABEL | FIRST_LOCATION_ONLY);
+    ResultDisplayPanel->EnableStartWithFourierScaling( );
+    ResultDisplayPanel->EnableDoNotShowStatusBar( );
+    ResultDisplayPanel->EnableStartWithNoLabel( );
+    ResultDisplayPanel->EnableFirstLocationOnly( );
+    ResultDisplayPanel->Initialise( );
     GuinierPlot->Initialise(wxT("Spatial Freq. (1/Å)"), "Log Amplitude", true, 20, 45, 30, 20, true, false);
     SetInfo( );
 

--- a/src/gui/ShowCTFResultsPanel.cpp
+++ b/src/gui/ShowCTFResultsPanel.cpp
@@ -9,7 +9,13 @@ ShowCTFResultsPanel::ShowCTFResultsPanel(wxWindow* parent, wxWindowID id, const 
     CTF2DResultsPanel->font_size_multiplier = 1.5;
     CTF2DResultsPanel->use_auto_contrast    = false;
 
-    ImageDisplayPanel->Initialise(CAN_FFT | NO_NOTEBOOK | FIRST_LOCATION_ONLY | START_WITH_AUTO_CONTRAST | START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR);
+    ImageDisplayPanel->EnableCanFFT( );
+    ImageDisplayPanel->EnableNoNotebook( );
+    ImageDisplayPanel->EnableFirstLocationOnly( );
+    ImageDisplayPanel->EnableStartWithAutoContrast( );
+    ImageDisplayPanel->EnableStartWithFourierScaling( );
+    ImageDisplayPanel->EnableDoNotShowStatusBar( );
+    ImageDisplayPanel->Initialise( );
 }
 
 ShowCTFResultsPanel::~ShowCTFResultsPanel( ) {

--- a/src/gui/ShowTemplateMatchResultsPanel.cpp
+++ b/src/gui/ShowTemplateMatchResultsPanel.cpp
@@ -7,7 +7,12 @@ extern MyVolumeAssetPanel* volume_asset_panel;
 ShowTemplateMatchResultsPanel::ShowTemplateMatchResultsPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style)
     : ShowTemplateMatchResultsPanelParent(parent, id, pos, size, style) {
     HistogramPlotPanel->Initialise(wxT("Correlation Value"), "", false, false, 20, 50, 60, 20, true, false, true);
-    ImageDisplayPanel->Initialise(FIRST_LOCATION_ONLY | START_WITH_AUTO_CONTRAST | START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR | SKIP_LEFTCLICK_TO_PARENT);
+    ImageDisplayPanel->EnableFirstLocationOnly( );
+    ImageDisplayPanel->EnableStartWithAutoContrast( );
+    ImageDisplayPanel->EnableStartWithFourierScaling( );
+    ImageDisplayPanel->EnableDoNotShowStatusBar( );
+    ImageDisplayPanel->EnableSkipLeftclickToParent( );
+    ImageDisplayPanel->Initialise( );
 
     PeakListCtrl->Bind(wxEVT_LIST_ITEM_SELECTED, &ShowTemplateMatchResultsPanel::OnPeakListSelectionChange, this);
     PeakListCtrl->Bind(wxEVT_LIST_ITEM_DESELECTED, &ShowTemplateMatchResultsPanel::OnPeakListSelectionChange, this);

--- a/src/gui/UnblurResultsPanel.cpp
+++ b/src/gui/UnblurResultsPanel.cpp
@@ -3,7 +3,13 @@
 
 UnblurResultsPanel::UnblurResultsPanel(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style, const wxString& name)
     : UnblurResultsPanelParent(parent, id, pos, size, style) {
-    ImageDisplayPanel->Initialise(CAN_FFT | NO_NOTEBOOK | FIRST_LOCATION_ONLY | START_WITH_AUTO_CONTRAST | START_WITH_FOURIER_SCALING | DO_NOT_SHOW_STATUS_BAR);
+    ImageDisplayPanel->EnableCanFFT( );
+    ImageDisplayPanel->EnableNoNotebook( );
+    ImageDisplayPanel->EnableFirstLocationOnly( );
+    ImageDisplayPanel->EnableStartWithAutoContrast( );
+    ImageDisplayPanel->EnableStartWithFourierScaling( );
+    ImageDisplayPanel->EnableDoNotShowStatusBar( );
+    ImageDisplayPanel->Initialise( );
 
     current_x_shift_vector_layer = new mpFXYVector(("X-Shift"));
     current_y_shift_vector_layer = new mpFXYVector(("Y-Shift"));


### PR DESCRIPTION
# Description
Just a small, single line change added as a requested feature; it is a built in wxAuiNotebook functionality I found while reading the wxWidgets docs. Now when hovering tab names on the DisplayNotebook, the full path to the file is displayed as a tooltip. This should be somewhat helpful if output images are being placed into different directories while testing changes to output images is being performed.

This was mainly meant as an addition to the cisTEM_display program, but would theoretically appear anywhere the DisplayPanel is used and tabs are allowed. If this behavior is not desired, it is a very easy change by simply adding a check with the flag `bool DisplayPanel::is_from_display_program`.

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
