### PR TITLE
Pixel size should be assigned when importing refinement package

### DIFF
--- a/src/gui/ImportRefinementPackageWizard.cpp
+++ b/src/gui/ImportRefinementPackageWizard.cpp
@@ -214,7 +214,7 @@ void ImportRefinementPackageWizard::OnFinished(wxWizardEvent& event) {
         //		temp_particle_info.microscope_voltage = MicroscopeVoltageTextCtrl->ReturnValue();
         temp_particle_info.parent_image_id    = -1;
         temp_particle_info.amplitude_contrast = input_star_file.ReturnAmplitudeContrast(0); // FIXME should be for all lines.
-        //		temp_particle_info.pixel_size = PixelSizeTextCtrl->ReturnValue();
+        temp_particle_info.pixel_size         = input_star_file.ReturnPixelSize(0);
         //		temp_particle_info.amplitude_contrast = AmplitudeContrastTextCtrl->ReturnValue();
         temp_particle_info.x_pos = 0;
         temp_particle_info.y_pos = 0;

--- a/src/gui/ImportRefinementPackageWizard.cpp
+++ b/src/gui/ImportRefinementPackageWizard.cpp
@@ -138,221 +138,173 @@ void ImportRefinementPackageWizard::OnUpdateUI(wxUpdateUIEvent& event) {
     }
 }
 
-void ImportRefinementPackageWizard::OnFinished(wxWizardEvent& event) {
-    // get the stack details..
+template <typename StarFileSource_t>
+void ImportRefinementPackageWizard::ImportRefinementPackage(StarFileSource_t& input_params_file, const int stack_x_size, const int stack_num_images) {
+    float    pixel_size;
+    float    spherical_aberration_nm;
+    float    microscope_voltage_kv;
+    float    amplitude_contrast;
+    float    molecular_weight_kda;
+    float    largest_dimension;
+    wxString refinement_package_name;
+    wxString symmetry;
 
-    int stack_x_size;
-    int stack_y_size;
-    int stack_number_of_images;
-
-    RefinementPackage*            temp_refinement_package;
+    RefinementPackage*            temp_refinement_package = new RefinementPackage( );
     RefinementPackageParticleInfo temp_particle_info;
     Refinement                    temp_refinement;
 
-    bool stack_is_ok = GetMRCDetails(ParticleStackFileTextCtrl->GetLineText(0).ToUTF8( ).data( ), stack_x_size, stack_y_size, stack_number_of_images);
+    constexpr bool is_cistem_import   = std::is_same_v<StarFileSource_t, cisTEMParameters>;
+    constexpr bool is_frealign_import = std::is_same_v<StarFileSource_t, FrealignParameterFile>;
+    constexpr bool is_relion_import   = std::is_same_v<StarFileSource_t, BasicStarFileReader>;
 
-    if ( stack_is_ok == false ) {
-        wxMessageBox(wxT("Error: Cannot read the stack file - aborting."), wxT("Error Reading particle stack"), wxICON_ERROR);
-        return;
+    if constexpr ( is_cistem_import ) {
+        refinement_package_name = wxString::Format("Refinement Package #%li (cisTEM Import)",
+                                                   refinement_package_asset_panel->current_asset_number);
+
+        pixel_size            = input_params_file.ReturnPixelSize(0);
+        microscope_voltage_kv = input_params_file.ReturnMicroscopekV(0);
+        amplitude_contrast    = input_params_file.ReturnAmplitudeContrast(0);
+    }
+    else if constexpr ( is_frealign_import ) {
+        refinement_package_name = wxString::Format("Refinement Package #%li (Frealign Import)",
+                                                   refinement_package_asset_panel->current_asset_number);
+
+        pixel_size            = PixelSizeTextCtrl->ReturnValue( );
+        microscope_voltage_kv = MicroscopeVoltageTextCtrl->ReturnValue( );
+        amplitude_contrast    = AmplitudeContrastTextCtrl->ReturnValue( );
+    }
+    else if constexpr ( is_relion_import ) {
+        refinement_package_name = wxString::Format("Refinement Package #%li (Relion Import)",
+                                                   refinement_package_asset_panel->current_asset_number);
+
+        pixel_size            = PixelSizeTextCtrl->ReturnValue( );
+        microscope_voltage_kv = MicroscopeVoltageTextCtrl->ReturnValue( );
+        amplitude_contrast    = AmplitudeContrastTextCtrl->ReturnValue( );
     }
 
-    if ( stack_x_size != stack_y_size ) {
-        wxMessageBox(wxT("Error: Only square images are currently supported - aborting."), wxT("Error images are not square"), wxICON_ERROR);
-        return;
-    }
+    spherical_aberration_nm = SphericalAberrationTextCtrl->ReturnValue( );
+    molecular_weight_kda    = MolecularWeightTextCtrl->ReturnValue( );
+    largest_dimension       = LargestDimensionTextCtrl->ReturnValue( );
+    symmetry                = SymmetryComboBox->GetValue( ).Upper( );
 
-    // hmm, so now I guess we have to actually do the import..
-    if ( cisTEMRadioButton->GetValue( ) == true ) // cisTEM
-    {
+    OneSecondProgressDialog* my_dialog = new OneSecondProgressDialog("Refinement Package", "Creating Refinement Package...", stack_num_images, this, wxPD_REMAINING_TIME | wxPD_AUTO_HIDE | wxPD_APP_MODAL);
 
-        cisTEMParameters input_star_file;
-        // Method creates a cisTEMStarFileReader object and reads in
-        input_star_file.ReadFromcisTEMStarFile(MetaDataFileTextCtrl->GetLineText(0), true);
+    // create the refinement package and intial refinement..
+    temp_refinement_package->name                     = refinement_package_name;
+    temp_refinement_package->number_of_classes        = 1;
+    temp_refinement_package->number_of_run_refinments = 0;
+    temp_refinement_package->stack_has_white_protein  = WhiteProteinRadioButton->GetValue( );
+    temp_refinement_package->output_pixel_size        = pixel_size;
 
-        if ( stack_number_of_images != input_star_file.ReturnNumberofLines( ) ) {
-            wxMessageBox(wxT("Error: Number of images in stack is different from\nthe number of lines in the star file - aborting."), wxT("Error: Number Mismatch"), wxICON_ERROR);
-            return;
+    temp_refinement.number_of_classes                = temp_refinement_package->number_of_classes;
+    temp_refinement.number_of_particles              = stack_num_images;
+    temp_refinement.name                             = "Imported Parameters";
+    temp_refinement.resolution_statistics_box_size   = stack_x_size;
+    temp_refinement.resolution_statistics_pixel_size = pixel_size;
+    temp_refinement.refinement_package_asset_id      = refinement_package_asset_panel->current_asset_number + 1;
+
+    temp_refinement_package->stack_box_size                       = stack_x_size;
+    temp_refinement_package->stack_filename                       = ParticleStackFileTextCtrl->GetLineText(0);
+    temp_refinement_package->symmetry                             = symmetry;
+    temp_refinement_package->estimated_particle_weight_in_kda     = molecular_weight_kda;
+    temp_refinement_package->estimated_particle_size_in_angstroms = largest_dimension;
+
+    long refinement_id = main_frame->current_project.database.ReturnHighestRefinementID( ) + 1;
+    temp_refinement_package->refinement_ids.Add(refinement_id);
+    temp_refinement_package->references_for_next_refinement.Add(-1);
+
+    temp_refinement.refinement_id                       = refinement_id;
+    temp_refinement.resolution_statistics_are_generated = true;
+
+    // These will all be the same and don't need to be changed during each iteration
+    temp_particle_info.spherical_aberration = spherical_aberration_nm;
+    temp_particle_info.microscope_voltage   = microscope_voltage_kv;
+    temp_particle_info.parent_image_id      = -1;
+    temp_particle_info.amplitude_contrast   = amplitude_contrast;
+
+    temp_particle_info.pixel_size = pixel_size;
+    temp_particle_info.x_pos      = 0;
+    temp_particle_info.y_pos      = 0;
+
+    temp_refinement.SizeAndFillWithEmpty(stack_num_images, 1);
+    temp_refinement.class_refinement_results[0].class_resolution_statistics.Init(pixel_size, temp_refinement.resolution_statistics_box_size);
+    temp_refinement.class_refinement_results[0].class_resolution_statistics.GenerateDefaultStatistics(temp_refinement_package->estimated_particle_weight_in_kda);
+
+    for ( int particle_counter = 0; particle_counter < stack_num_images; particle_counter++ ) {
+        // cisTEMParameters and BasicStarFileReader (for reading Relion format) have several identical function names that can be lumped together; so, to save code,
+        // they are included in this if block, with further specific checks for divergence in parameter loading.
+        if constexpr ( is_cistem_import || is_relion_import ) {
+
+            // Start with particles' info, then perform checks to see which format we're using to finish filling the info
+            temp_particle_info.original_particle_position_asset_id = input_params_file.ReturnPositionInStack(particle_counter);
+            temp_particle_info.position_in_stack                   = input_params_file.ReturnPositionInStack(particle_counter);
+            temp_particle_info.defocus_1                           = input_params_file.ReturnDefocus1(particle_counter);
+            temp_particle_info.defocus_2                           = input_params_file.ReturnDefocus2(particle_counter);
+            temp_particle_info.defocus_angle                       = input_params_file.ReturnDefocusAngle(particle_counter);
+            temp_particle_info.phase_shift                         = input_params_file.ReturnPhaseShift(particle_counter);
+            temp_particle_info.assigned_subset                     = input_params_file.ReturnAssignedSubset(particle_counter);
+
+            // Finish the particles' info with specific checks, and while doing so, fill in specific refinement result parameters as well
+            if constexpr ( is_relion_import ) {
+                temp_particle_info.amplitude_contrast = amplitude_contrast;
+                temp_particle_info.pixel_size         = pixel_size;
+                temp_refinement_package->contained_particles.Add(temp_particle_info);
+
+                if ( input_params_file.x_shifts_are_in_angst )
+                    temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].xshift = -input_params_file.ReturnXShift(particle_counter);
+                else
+                    temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].xshift = -input_params_file.ReturnXShift(particle_counter) * pixel_size;
+
+                if ( input_params_file.y_shifts_are_in_angst )
+                    temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].yshift = -input_params_file.ReturnYShift(particle_counter);
+                else
+                    temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].yshift = -input_params_file.ReturnYShift(particle_counter) * pixel_size;
+
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].score           = 0.0;
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_is_active = 1;
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].sigma           = 10.0;
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].logp            = 0.0;
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].occupancy       = 100.0;
+            }
+            else if constexpr ( is_cistem_import ) {
+                temp_particle_info.pixel_size         = input_params_file.ReturnPixelSize(particle_counter);
+                temp_particle_info.amplitude_contrast = input_params_file.ReturnAmplitudeContrast(particle_counter);
+                temp_refinement_package->contained_particles.Add(temp_particle_info);
+
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].xshift          = input_params_file.ReturnXShift(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].yshift          = input_params_file.ReturnYShift(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].score           = input_params_file.ReturnScore(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_is_active = (int)input_params_file.ReturnImageIsActive(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].sigma           = input_params_file.ReturnSigma(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].beam_tilt_x     = input_params_file.ReturnBeamTiltX(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].beam_tilt_y     = input_params_file.ReturnBeamTiltY(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_shift_x   = input_params_file.ReturnImageShiftX(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_shift_y   = input_params_file.ReturnImageShiftY(particle_counter);
+
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].beam_tilt_group = input_params_file.ReturnBeamTiltGroup(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].particle_group  = input_params_file.ReturnParticleGroup(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].pre_exposure    = input_params_file.ReturnPreExposure(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].total_exposure  = input_params_file.ReturnTotalExposure(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].logp            = input_params_file.ReturnLogP(particle_counter);
+                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].occupancy       = input_params_file.ReturnOccupancy(particle_counter);
+            }
+
+            // Finish filling in the parameters that have the same function names and can be retrieved the same way for cisTEM/Relion imports
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].position_in_stack = (int)input_params_file.ReturnPositionInStack(particle_counter);
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus1          = input_params_file.ReturnDefocus1(particle_counter);
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus2          = input_params_file.ReturnDefocus2(particle_counter);
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus_angle     = input_params_file.ReturnDefocusAngle(particle_counter);
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].phase_shift       = input_params_file.ReturnPhaseShift(particle_counter);
+
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].phi             = input_params_file.ReturnPhi(particle_counter);
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].theta           = input_params_file.ReturnTheta(particle_counter);
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].psi             = input_params_file.ReturnPsi(particle_counter);
+            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].assigned_subset = input_params_file.ReturnAssignedSubset(particle_counter);
         }
-
-        OneSecondProgressDialog* my_dialog = new OneSecondProgressDialog("Refinement Package", "Creating Refinement Package...", stack_number_of_images, this, wxPD_REMAINING_TIME | wxPD_AUTO_HIDE | wxPD_APP_MODAL);
-
-        // create the refinement package and intial refinement..
-
-        temp_refinement_package = new RefinementPackage;
-        temp_refinement.SizeAndFillWithEmpty(stack_number_of_images, 1);
-
-        temp_refinement_package->name                     = wxString::Format("Refinement Package #%li (cisTEM Import)", refinement_package_asset_panel->current_asset_number);
-        temp_refinement_package->number_of_classes        = 1;
-        temp_refinement_package->number_of_run_refinments = 0;
-        temp_refinement_package->stack_has_white_protein  = WhiteProteinRadioButton->GetValue( );
-        temp_refinement_package->output_pixel_size        = input_star_file.ReturnPixelSize(0); // FIXME should be for all lines.
-        //		temp_refinement_package->output_pixel_size = PixelSizeTextCtrl->ReturnValue();
-
-        temp_refinement.number_of_classes                = temp_refinement_package->number_of_classes;
-        temp_refinement.number_of_particles              = stack_number_of_images;
-        temp_refinement.name                             = "Imported Parameters";
-        temp_refinement.resolution_statistics_box_size   = stack_x_size;
-        temp_refinement.resolution_statistics_pixel_size = input_star_file.ReturnPixelSize(0); // FIXME should be for all lines.
-        //		temp_refinement.resolution_statistics_pixel_size = PixelSizeTextCtrl->ReturnValue();
-        temp_refinement.refinement_package_asset_id = refinement_package_asset_panel->current_asset_number + 1;
-
-        temp_refinement_package->stack_box_size                       = stack_x_size;
-        temp_refinement_package->stack_filename                       = ParticleStackFileTextCtrl->GetLineText(0);
-        temp_refinement_package->symmetry                             = SymmetryComboBox->GetValue( ).Upper( );
-        temp_refinement_package->estimated_particle_weight_in_kda     = MolecularWeightTextCtrl->ReturnValue( );
-        temp_refinement_package->estimated_particle_size_in_angstroms = LargestDimensionTextCtrl->ReturnValue( );
-
-        long refinement_id = main_frame->current_project.database.ReturnHighestRefinementID( ) + 1;
-        temp_refinement_package->refinement_ids.Add(refinement_id);
-        temp_refinement_package->references_for_next_refinement.Add(-1);
-
-        temp_refinement.refinement_id                       = refinement_id;
-        temp_refinement.resolution_statistics_are_generated = true;
-
-        temp_particle_info.spherical_aberration = SphericalAberrationTextCtrl->ReturnValue( );
-        temp_particle_info.microscope_voltage   = input_star_file.ReturnMicroscopekV(0); // FIXME should be for all lines.
-        //		temp_particle_info.microscope_voltage = MicroscopeVoltageTextCtrl->ReturnValue();
-        temp_particle_info.parent_image_id    = -1;
-        temp_particle_info.amplitude_contrast = input_star_file.ReturnAmplitudeContrast(0); // FIXME should be for all lines.
-        temp_particle_info.pixel_size         = input_star_file.ReturnPixelSize(0);
-        //		temp_particle_info.amplitude_contrast = AmplitudeContrastTextCtrl->ReturnValue();
-        temp_particle_info.x_pos = 0;
-        temp_particle_info.y_pos = 0;
-
-        temp_refinement.class_refinement_results[0].class_resolution_statistics.Init(temp_particle_info.pixel_size, temp_refinement.resolution_statistics_box_size);
-        temp_refinement.class_refinement_results[0].class_resolution_statistics.GenerateDefaultStatistics(temp_refinement_package->estimated_particle_weight_in_kda);
-
-        // loop over all particles
-
-        for ( int particle_counter = 0; particle_counter < stack_number_of_images; particle_counter++ ) {
-
-            temp_particle_info.original_particle_position_asset_id = (int)input_star_file.ReturnPositionInStack(particle_counter);
-            temp_particle_info.position_in_stack                   = (int)input_star_file.ReturnPositionInStack(particle_counter);
-            temp_particle_info.defocus_1                           = input_star_file.ReturnDefocus1(particle_counter);
-            temp_particle_info.defocus_2                           = input_star_file.ReturnDefocus2(particle_counter);
-            temp_particle_info.defocus_angle                       = input_star_file.ReturnDefocusAngle(particle_counter);
-            temp_particle_info.phase_shift                         = input_star_file.ReturnPhaseShift(particle_counter);
-            temp_particle_info.pixel_size                          = input_star_file.ReturnPixelSize(particle_counter);
-            temp_particle_info.amplitude_contrast                  = input_star_file.ReturnAmplitudeContrast(particle_counter);
-            temp_particle_info.assigned_subset                     = input_star_file.ReturnAssignedSubset(particle_counter);
-
-            temp_refinement_package->contained_particles.Add(temp_particle_info);
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].position_in_stack = (int)input_star_file.ReturnPositionInStack(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus1          = input_star_file.ReturnDefocus1(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus2          = input_star_file.ReturnDefocus2(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus_angle     = input_star_file.ReturnDefocusAngle(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].phase_shift       = input_star_file.ReturnPhaseShift(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].logp              = input_star_file.ReturnLogP(particle_counter);
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].occupancy       = input_star_file.ReturnOccupancy(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].phi             = input_star_file.ReturnPhi(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].theta           = input_star_file.ReturnTheta(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].psi             = input_star_file.ReturnPsi(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].xshift          = input_star_file.ReturnXShift(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].yshift          = input_star_file.ReturnYShift(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].score           = input_star_file.ReturnScore(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_is_active = (int)input_star_file.ReturnImageIsActive(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].sigma           = input_star_file.ReturnSigma(particle_counter);
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].pixel_size                         = input_star_file.ReturnPixelSize(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_voltage_kv              = input_star_file.ReturnMicroscopekV(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_spherical_aberration_mm = input_star_file.ReturnMicroscopeCs(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].amplitude_contrast                 = input_star_file.ReturnAmplitudeContrast(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].beam_tilt_x                        = input_star_file.ReturnBeamTiltX(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].beam_tilt_y                        = input_star_file.ReturnBeamTiltY(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_shift_x                      = input_star_file.ReturnImageShiftX(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_shift_y                      = input_star_file.ReturnImageShiftY(particle_counter);
-
-            //
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].beam_tilt_group = input_star_file.ReturnBeamTiltGroup(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].particle_group  = input_star_file.ReturnParticleGroup(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].assigned_subset = input_star_file.ReturnAssignedSubset(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].pre_exposure    = input_star_file.ReturnPreExposure(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].total_exposure  = input_star_file.ReturnTotalExposure(particle_counter);
-
-            my_dialog->Update(particle_counter + 1);
-        }
-
-        // add to the database and panel..
-
-        main_frame->current_project.database.Begin( );
-        wxPrintf("\t\t\n\nAdding the temp refinement from the cisTEM import dialog\n\n");
-        refinement_package_asset_panel->AddAsset(temp_refinement_package);
-        main_frame->current_project.database.AddRefinement(&temp_refinement);
-
-        ArrayofAngularDistributionHistograms all_histograms = temp_refinement.ReturnAngularDistributions(temp_refinement_package->symmetry);
-        for ( int class_counter = 0; class_counter < temp_refinement.number_of_classes; class_counter++ ) {
-            main_frame->current_project.database.AddRefinementAngularDistribution(all_histograms[class_counter], temp_refinement.refinement_id, class_counter + 1);
-        }
-
-        ShortRefinementInfo temp_info;
-        temp_info = temp_refinement;
-
-        refinement_package_asset_panel->all_refinement_short_infos.Add(temp_info);
-        main_frame->current_project.database.Commit( );
-        my_dialog->Destroy( );
-    }
-    else if ( FrealignRadioButton->GetValue( ) == true ) // FREALIGN
-    {
-        FrealignParameterFile input_par_file(MetaDataFileTextCtrl->GetLineText(0), OPEN_TO_READ);
-        input_par_file.ReadFile(false, stack_number_of_images);
-
-        if ( stack_number_of_images != input_par_file.number_of_lines ) {
-            wxMessageBox(wxT("Error: Number of images in stack is different from\nthe number of lines in the par file - aborting."), wxT("Error: Number Mismatch"), wxICON_ERROR);
-            return;
-        }
-
-        OneSecondProgressDialog* my_dialog = new OneSecondProgressDialog("Refinement Package", "Creating Refinement Package...", stack_number_of_images, this, wxPD_REMAINING_TIME | wxPD_AUTO_HIDE | wxPD_APP_MODAL);
-
-        float input_parameters[17];
-
-        // create the refinement package and intial refinement..
-
-        temp_refinement_package = new RefinementPackage;
-        temp_refinement.SizeAndFillWithEmpty(stack_number_of_images, 1);
-
-        temp_refinement_package->name                     = wxString::Format("Refinement Package #%li (Frealign Import)", refinement_package_asset_panel->current_asset_number);
-        temp_refinement_package->number_of_classes        = 1;
-        temp_refinement_package->number_of_run_refinments = 0;
-        temp_refinement_package->stack_has_white_protein  = WhiteProteinRadioButton->GetValue( );
-        temp_refinement_package->output_pixel_size        = PixelSizeTextCtrl->ReturnValue( );
-
-        temp_refinement.number_of_classes                = temp_refinement_package->number_of_classes;
-        temp_refinement.number_of_particles              = stack_number_of_images;
-        temp_refinement.name                             = "Imported Parameters";
-        temp_refinement.resolution_statistics_box_size   = stack_x_size;
-        temp_refinement.resolution_statistics_pixel_size = PixelSizeTextCtrl->ReturnValue( );
-        temp_refinement.refinement_package_asset_id      = refinement_package_asset_panel->current_asset_number + 1;
-
-        temp_refinement_package->stack_box_size                       = stack_x_size;
-        temp_refinement_package->stack_filename                       = ParticleStackFileTextCtrl->GetLineText(0);
-        temp_refinement_package->symmetry                             = SymmetryComboBox->GetValue( ).Upper( );
-        temp_refinement_package->estimated_particle_weight_in_kda     = MolecularWeightTextCtrl->ReturnValue( );
-        temp_refinement_package->estimated_particle_size_in_angstroms = LargestDimensionTextCtrl->ReturnValue( );
-
-        long refinement_id = main_frame->current_project.database.ReturnHighestRefinementID( ) + 1;
-        temp_refinement_package->refinement_ids.Add(refinement_id);
-        temp_refinement_package->references_for_next_refinement.Add(-1);
-
-        temp_refinement.refinement_id                       = refinement_id;
-        temp_refinement.resolution_statistics_are_generated = true;
-
-        temp_particle_info.spherical_aberration = SphericalAberrationTextCtrl->ReturnValue( );
-        temp_particle_info.microscope_voltage   = MicroscopeVoltageTextCtrl->ReturnValue( );
-        temp_particle_info.parent_image_id      = -1;
-        temp_particle_info.pixel_size           = PixelSizeTextCtrl->ReturnValue( );
-        temp_particle_info.amplitude_contrast   = AmplitudeContrastTextCtrl->ReturnValue( );
-        temp_particle_info.x_pos                = 0;
-        temp_particle_info.y_pos                = 0;
-
-        temp_refinement.class_refinement_results[0].class_resolution_statistics.Init(temp_particle_info.pixel_size, temp_refinement.resolution_statistics_box_size);
-        temp_refinement.class_refinement_results[0].class_resolution_statistics.GenerateDefaultStatistics(temp_refinement_package->estimated_particle_weight_in_kda);
-
-        // loop over all particles
-        int current_subset;
-        for ( int particle_counter = 0; particle_counter < stack_number_of_images; particle_counter++ ) {
-            input_par_file.ReadLine(input_parameters);
+        else if constexpr ( is_frealign_import ) {
+            float input_parameters[17];
+            int   current_subset;
+            input_params_file.ReadLine(input_parameters);
 
             temp_particle_info.original_particle_position_asset_id = int(input_parameters[0]);
             temp_particle_info.position_in_stack                   = int(input_parameters[0]);
@@ -362,7 +314,7 @@ void ImportRefinementPackageWizard::OnFinished(wxWizardEvent& event) {
             temp_particle_info.phase_shift                         = input_parameters[11];
 
             // we split the stack in 10 and assign half-dataset membership accordingly
-            if ( particle_counter / (stack_number_of_images / 10) % 2 ) {
+            if ( particle_counter / (stack_num_images / 10) % 2 ) {
                 current_subset = 1;
             }
             else {
@@ -389,38 +341,79 @@ void ImportRefinementPackageWizard::OnFinished(wxWizardEvent& event) {
             temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_is_active = int(input_parameters[7]);
             temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].sigma           = input_parameters[14];
 
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].pixel_size                         = PixelSizeTextCtrl->ReturnValue( );
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_voltage_kv              = MicroscopeVoltageTextCtrl->ReturnValue( );
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_spherical_aberration_mm = SphericalAberrationTextCtrl->ReturnValue( );
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].amplitude_contrast                 = AmplitudeContrastTextCtrl->ReturnValue( );
-
             temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].assigned_subset = current_subset;
-
-            my_dialog->Update(particle_counter + 1);
         }
+        // These are general to ALL types of parameters files? Worth checking with Tim about
+        temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].pixel_size                         = pixel_size;
+        temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_voltage_kv              = microscope_voltage_kv;
+        temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_spherical_aberration_mm = spherical_aberration_nm;
+        temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].amplitude_contrast                 = amplitude_contrast;
 
-        // add to the database and panel..
-
-        main_frame->current_project.database.Begin( );
-
-        refinement_package_asset_panel->AddAsset(temp_refinement_package);
-        main_frame->current_project.database.AddRefinement(&temp_refinement);
-
-        ArrayofAngularDistributionHistograms all_histograms = temp_refinement.ReturnAngularDistributions(temp_refinement_package->symmetry);
-        for ( int class_counter = 0; class_counter < temp_refinement.number_of_classes; class_counter++ ) {
-            main_frame->current_project.database.AddRefinementAngularDistribution(all_histograms[class_counter], temp_refinement.refinement_id, class_counter + 1);
-        }
-
-        ShortRefinementInfo temp_info;
-        temp_info = temp_refinement;
-
-        refinement_package_asset_panel->all_refinement_short_infos.Add(temp_info);
-        main_frame->current_project.database.Commit( );
-        my_dialog->Destroy( );
+        my_dialog->Update(particle_counter + 1);
     }
-    else if ( RelionRadioButton->GetValue( ) == true ) // RELION
-    {
 
+    // add to the database and panel..
+    main_frame->current_project.database.Begin( );
+    refinement_package_asset_panel->AddAsset(temp_refinement_package);
+    main_frame->current_project.database.AddRefinement(&temp_refinement);
+
+    ArrayofAngularDistributionHistograms all_histograms = temp_refinement.ReturnAngularDistributions(temp_refinement_package->symmetry);
+    for ( int class_counter = 0; class_counter < temp_refinement.number_of_classes; class_counter++ ) {
+        main_frame->current_project.database.AddRefinementAngularDistribution(all_histograms[class_counter], temp_refinement.refinement_id, class_counter + 1);
+    }
+
+    ShortRefinementInfo temp_info;
+    temp_info = temp_refinement;
+    refinement_package_asset_panel->all_refinement_short_infos.Add(temp_info);
+
+    main_frame->current_project.database.Commit( );
+    my_dialog->Destroy( );
+}
+
+template void ImportRefinementPackageWizard::ImportRefinementPackage<cisTEMParameters>(cisTEMParameters& input_params_file, const int stack_x_size, const int stack_num_images);
+template void ImportRefinementPackageWizard::ImportRefinementPackage<FrealignParameterFile>(FrealignParameterFile& input_params_file, const int stack_x_size, const int stack_num_images);
+template void ImportRefinementPackageWizard::ImportRefinementPackage<BasicStarFileReader>(BasicStarFileReader& input_params_file, const int stack_x_size, const int stack_num_images);
+
+void ImportRefinementPackageWizard::OnFinished(wxWizardEvent& event) {
+    int stack_x_size;
+    int stack_y_size;
+    int stack_number_of_images;
+
+    // Verify stack integrity, check which type of import we're doing
+    bool stack_is_ok = GetMRCDetails(ParticleStackFileTextCtrl->GetLineText(0).ToUTF8( ).data( ), stack_x_size, stack_y_size, stack_number_of_images);
+
+    if ( ! stack_is_ok ) {
+        wxMessageBox(wxT("Error: Cannot read the stack file - aborting."), wxT("Error Reading particle stack"), wxICON_ERROR);
+        return;
+    }
+
+    if ( stack_x_size != stack_y_size ) {
+        wxMessageBox(wxT("Error: Only square images are currently supported - aborting."), wxT("Error images are not square"), wxICON_ERROR);
+        return;
+    }
+
+    if ( cisTEMRadioButton->GetValue( ) == true ) {
+
+        cisTEMParameters input_star_file;
+        input_star_file.ReadFromcisTEMStarFile(MetaDataFileTextCtrl->GetLineText(0), true);
+
+        if ( stack_number_of_images != input_star_file.ReturnNumberofLines( ) ) {
+            wxMessageBox(wxT("Error: Number of images in stack is different from\nthe number of lines in the star file - aborting."), wxT("Error: Number Mismatch"), wxICON_ERROR);
+            return;
+        }
+        ImportRefinementPackage(input_star_file, stack_x_size, stack_number_of_images);
+    }
+    else if ( FrealignRadioButton->GetValue( ) == true ) {
+        FrealignParameterFile input_par_file(MetaDataFileTextCtrl->GetLineText(0), OPEN_TO_READ);
+        input_par_file.ReadFile(false, stack_number_of_images);
+
+        if ( stack_number_of_images != input_par_file.number_of_lines ) {
+            wxMessageBox(wxT("Error: Number of images in stack is different from\nthe number of lines in the par file - aborting."), wxT("Error: Number Mismatch"), wxICON_ERROR);
+            return;
+        }
+        ImportRefinementPackage(input_par_file, stack_x_size, stack_number_of_images);
+    }
+    else if ( RelionRadioButton->GetValue( ) == true ) {
         BasicStarFileReader input_star_file;
         wxString            star_error_text;
 
@@ -433,144 +426,6 @@ void ImportRefinementPackageWizard::OnFinished(wxWizardEvent& event) {
             wxMessageBox(wxString::Format("Error: Number of images(%i) in stack is different from\nthe number of parameters read from the star file(%i) - aborting.", stack_number_of_images, input_star_file.cached_parameters.GetCount( )), wxT("Error: Number Mismatch"), wxICON_ERROR);
             return;
         }
-
-        OneSecondProgressDialog* my_dialog = new OneSecondProgressDialog("Refinement Package", "Creating Refinement Package...", stack_number_of_images, this, wxPD_REMAINING_TIME | wxPD_AUTO_HIDE | wxPD_APP_MODAL);
-
-        // create the refinement package and intial refinement..
-
-        temp_refinement_package = new RefinementPackage;
-        temp_refinement.SizeAndFillWithEmpty(stack_number_of_images, 1);
-
-        temp_refinement_package->name                     = wxString::Format("Refinement Package #%li (Relion Import)", refinement_package_asset_panel->current_asset_number);
-        temp_refinement_package->number_of_classes        = 1;
-        temp_refinement_package->number_of_run_refinments = 0;
-        temp_refinement_package->stack_has_white_protein  = WhiteProteinRadioButton->GetValue( );
-        temp_refinement_package->output_pixel_size        = PixelSizeTextCtrl->ReturnValue( );
-
-        temp_refinement.number_of_classes                = temp_refinement_package->number_of_classes;
-        temp_refinement.number_of_particles              = stack_number_of_images;
-        temp_refinement.name                             = "Imported Parameters";
-        temp_refinement.resolution_statistics_box_size   = stack_x_size;
-        temp_refinement.resolution_statistics_pixel_size = PixelSizeTextCtrl->ReturnValue( );
-        temp_refinement.refinement_package_asset_id      = refinement_package_asset_panel->current_asset_number + 1;
-
-        temp_refinement_package->stack_box_size                       = stack_x_size;
-        temp_refinement_package->stack_filename                       = ParticleStackFileTextCtrl->GetLineText(0);
-        temp_refinement_package->symmetry                             = SymmetryComboBox->GetValue( ).Upper( );
-        temp_refinement_package->estimated_particle_weight_in_kda     = MolecularWeightTextCtrl->ReturnValue( );
-        temp_refinement_package->estimated_particle_size_in_angstroms = LargestDimensionTextCtrl->ReturnValue( );
-
-        long refinement_id = main_frame->current_project.database.ReturnHighestRefinementID( ) + 1;
-        temp_refinement_package->refinement_ids.Add(refinement_id);
-        temp_refinement_package->references_for_next_refinement.Add(-1);
-
-        temp_refinement.refinement_id                       = refinement_id;
-        temp_refinement.resolution_statistics_are_generated = true;
-
-        temp_particle_info.spherical_aberration = SphericalAberrationTextCtrl->ReturnValue( );
-        temp_particle_info.microscope_voltage   = MicroscopeVoltageTextCtrl->ReturnValue( );
-        temp_particle_info.parent_image_id      = -1;
-        temp_particle_info.pixel_size           = PixelSizeTextCtrl->ReturnValue( );
-        temp_particle_info.amplitude_contrast   = AmplitudeContrastTextCtrl->ReturnValue( );
-        temp_particle_info.x_pos                = 0;
-        temp_particle_info.y_pos                = 0;
-
-        temp_refinement.class_refinement_results[0].class_resolution_statistics.Init(temp_particle_info.pixel_size, temp_refinement.resolution_statistics_box_size);
-        temp_refinement.class_refinement_results[0].class_resolution_statistics.GenerateDefaultStatistics(temp_refinement_package->estimated_particle_weight_in_kda);
-
-        // loop over all particles
-
-        for ( int particle_counter = 0; particle_counter < stack_number_of_images; particle_counter++ ) {
-            temp_particle_info.original_particle_position_asset_id = input_star_file.ReturnPositionInStack(particle_counter);
-            temp_particle_info.position_in_stack                   = input_star_file.ReturnPositionInStack(particle_counter);
-            temp_particle_info.defocus_1                           = input_star_file.ReturnDefocus1(particle_counter);
-            temp_particle_info.defocus_2                           = input_star_file.ReturnDefocus2(particle_counter);
-            temp_particle_info.defocus_angle                       = input_star_file.ReturnDefocusAngle(particle_counter);
-            temp_particle_info.phase_shift                         = input_star_file.ReturnPhaseShift(particle_counter);
-
-            temp_particle_info.x_pos = input_star_file.ReturnXCoordinate(particle_counter) * PixelSizeTextCtrl->ReturnValue( );
-            temp_particle_info.y_pos = input_star_file.ReturnYCoordinate(particle_counter) * PixelSizeTextCtrl->ReturnValue( );
-
-            temp_particle_info.assigned_subset = input_star_file.ReturnAssignedSubset(particle_counter);
-
-            temp_refinement_package->contained_particles.Add(temp_particle_info);
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].position_in_stack = input_star_file.ReturnPositionInStack(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus1          = input_star_file.ReturnDefocus1(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus2          = input_star_file.ReturnDefocus2(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].defocus_angle     = input_star_file.ReturnDefocusAngle(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].phase_shift       = input_star_file.ReturnPhaseShift(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].logp              = 0;
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].occupancy = 100.0;
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].phi       = input_star_file.ReturnPhi(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].theta     = input_star_file.ReturnTheta(particle_counter);
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].psi       = input_star_file.ReturnPsi(particle_counter);
-
-            if ( input_star_file.x_shifts_are_in_angst ) {
-                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].xshift = -input_star_file.ReturnXShift(particle_counter);
-            }
-            else {
-                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].xshift = -input_star_file.ReturnXShift(particle_counter) * PixelSizeTextCtrl->ReturnValue( );
-            }
-
-            if ( input_star_file.y_shifts_are_in_angst ) {
-                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].yshift = -input_star_file.ReturnYShift(particle_counter);
-            }
-            else {
-                temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].yshift = -input_star_file.ReturnYShift(particle_counter) * PixelSizeTextCtrl->ReturnValue( );
-            }
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].score           = 0.0;
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].image_is_active = 1;
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].sigma           = 10.0;
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].pixel_size                         = PixelSizeTextCtrl->ReturnValue( );
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_voltage_kv              = MicroscopeVoltageTextCtrl->ReturnValue( );
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].microscope_spherical_aberration_mm = SphericalAberrationTextCtrl->ReturnValue( );
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].amplitude_contrast                 = AmplitudeContrastTextCtrl->ReturnValue( );
-
-            temp_refinement.class_refinement_results[0].particle_refinement_results[particle_counter].assigned_subset = input_star_file.ReturnAssignedSubset(particle_counter);
-
-            my_dialog->Update(particle_counter + 1);
-        }
-
-        // add to the database and panel..
-
-        main_frame->current_project.database.Begin( );
-        refinement_package_asset_panel->AddAsset(temp_refinement_package);
-        main_frame->current_project.database.AddRefinement(&temp_refinement);
-
-        ArrayofAngularDistributionHistograms all_histograms;
-        all_histograms = temp_refinement.ReturnAngularDistributions(temp_refinement_package->symmetry);
-        for ( int class_counter = 0; class_counter < temp_refinement.number_of_classes; class_counter++ ) {
-            main_frame->current_project.database.AddRefinementAngularDistribution(all_histograms[class_counter], temp_refinement.refinement_id, class_counter + 1);
-        }
-
-        ShortRefinementInfo temp_info;
-        temp_info = temp_refinement;
-
-        refinement_package_asset_panel->all_refinement_short_infos.Add(temp_info);
-        main_frame->current_project.database.Commit( );
-        my_dialog->Destroy( );
+        ImportRefinementPackage(input_star_file, stack_x_size, stack_number_of_images);
     }
-
-    /*
-	// create the directory if it doesn't exist (which it shouldn't)
-
-	wxFileName current_dirname = wxFileName::DirName(ProjectPathTextCtrl->GetValue());
-
-	if (current_dirname.Exists())
-	{
-		MyDebugPrintWithDetails("Directory should not already exist, and does!\n");
-	}
-	else current_dirname.Mkdir();
-
-	wxString wanted_database_file = ProjectPathTextCtrl->GetValue();
-	if (wanted_database_file.EndsWith("/") == false) wanted_database_file += "/";
-	wanted_database_file += ProjectNameTextCtrl->GetValue();
-	wanted_database_file += ".db";
-
-	main_frame->current_project.CreateNewProject(wanted_database_file, ProjectPathTextCtrl->GetValue(), ProjectNameTextCtrl->GetValue());
-	*/
 }

--- a/src/gui/ImportRefinementPackageWizard.h
+++ b/src/gui/ImportRefinementPackageWizard.h
@@ -1,5 +1,5 @@
-#ifndef __ImportRefinementPackageWizard__
-#define __ImportRefinementPackageWizard__
+#ifndef __src_gui_ImportRefinementPackageWizard__
+#define __src_gui_ImportRefinementPackageWizard__
 
 class ImportRefinementPackageWizard : public ImportRefinementPackageWizardParent {
   protected:
@@ -29,6 +29,9 @@ class ImportRefinementPackageWizard : public ImportRefinementPackageWizardParent
         if ( win )
             win->Enable(true);
     }
-};
 
+  private:
+    template <typename StarFileSource_t>
+    void ImportRefinementPackage(StarFileSource_t& input_params_file, const int stack_x_size, const int stack_num_images);
+};
 #endif

--- a/src/gui/ProjectX_gui_refinement_package.cpp
+++ b/src/gui/ProjectX_gui_refinement_package.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version 3.10.1-0-g8feb16b3)
+// C++ code generated with wxFormBuilder (version 3.10.0-4761b0c)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -539,7 +539,7 @@ RefinementPackageAssetPanel::RefinementPackageAssetPanel( wxWindow* parent, wxWi
 	ImportButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnImportClick ), NULL, this );
 	ExportButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnExportClick ), NULL, this );
 	CombineButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnCombineClick ), NULL, this );
-	BinButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnBinClick ), NULL, this );
+	BinButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnResampleClick ), NULL, this );
 	RefinementPackageListCtrl->Connect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( RefinementPackageAssetPanel::MouseCheckPackagesVeto ), NULL, this );
 	RefinementPackageListCtrl->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler( RefinementPackageAssetPanel::MouseCheckPackagesVeto ), NULL, this );
 	RefinementPackageListCtrl->Connect( wxEVT_LEFT_UP, wxMouseEventHandler( RefinementPackageAssetPanel::MouseVeto ), NULL, this );
@@ -578,7 +578,7 @@ RefinementPackageAssetPanel::~RefinementPackageAssetPanel()
 	ImportButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnImportClick ), NULL, this );
 	ExportButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnExportClick ), NULL, this );
 	CombineButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnCombineClick ), NULL, this );
-	BinButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnBinClick ), NULL, this );
+	BinButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( RefinementPackageAssetPanel::OnResampleClick ), NULL, this );
 	RefinementPackageListCtrl->Disconnect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( RefinementPackageAssetPanel::MouseCheckPackagesVeto ), NULL, this );
 	RefinementPackageListCtrl->Disconnect( wxEVT_LEFT_DOWN, wxMouseEventHandler( RefinementPackageAssetPanel::MouseCheckPackagesVeto ), NULL, this );
 	RefinementPackageListCtrl->Disconnect( wxEVT_LEFT_UP, wxMouseEventHandler( RefinementPackageAssetPanel::MouseVeto ), NULL, this );

--- a/src/gui/ProjectX_gui_refinement_package.h
+++ b/src/gui/ProjectX_gui_refinement_package.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version 3.10.1-0-g8feb16b3)
+// C++ code generated with wxFormBuilder (version 3.10.0-4761b0c)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -167,7 +167,7 @@ class RefinementPackageAssetPanel : public wxPanel
 		virtual void OnImportClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnExportClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCombineClick( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnBinClick( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnResampleClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void MouseCheckPackagesVeto( wxMouseEvent& event ) { event.Skip(); }
 		virtual void MouseVeto( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnBeginEdit( wxListEvent& event ) { event.Skip(); }

--- a/src/gui/wxformbuilder/ProjectX_refinement_package.fbp
+++ b/src/gui/wxformbuilder/ProjectX_refinement_package.fbp
@@ -2123,7 +2123,7 @@
                 </object>
             </object>
         </object>
-        <object class="Panel" expanded="0">
+        <object class="Panel" expanded="1">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -2147,7 +2147,7 @@
             <property name="window_name"></property>
             <property name="window_style">wxTAB_TRAVERSAL</property>
             <event name="OnUpdateUI">OnUpdateUI</event>
-            <object class="wxBoxSizer" expanded="0">
+            <object class="wxBoxSizer" expanded="1">
                 <property name="minimum_size"></property>
                 <property name="name">bSizer187</property>
                 <property name="orient">wxVERTICAL</property>
@@ -2210,7 +2210,7 @@
                         <property name="window_style"></property>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="0">
+                <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">1</property>
@@ -2980,7 +2980,7 @@
                                                             <property name="window_extra_style"></property>
                                                             <property name="window_name"></property>
                                                             <property name="window_style"></property>
-                                                            <event name="OnButtonClick">OnBinClick</event>
+                                                            <event name="OnButtonClick">OnResampleClick</event>
                                                         </object>
                                                     </object>
                                                 </object>
@@ -3538,7 +3538,7 @@
                         <property name="window_style"></property>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="0">
+                <object class="sizeritem" expanded="1">
                     <property name="border">5</property>
                     <property name="flag">wxEXPAND</property>
                     <property name="proportion">0</property>


### PR DESCRIPTION
# Description

This was an odd bug that took a little while to identify, but required only a single-line fix. When importing a refinement package using cisTEM parameters, the refinement being created for the new package was initialized using the pixel size from the particle info, but the particle info never had its pixel size value assigned from the imported parameters, so it was initialized to 0.

There were 2 symptoms: when attempting to do 3D refinement, the process would crash due to invalid SSNR values; and when displaying the various FSC values with the popup dialog on the refinement results panel, there was a clear issue in SSNR values, which would reach infinity:

![bad_fsc](https://github.com/user-attachments/assets/cac8f079-acb6-4c7f-9032-846a95f79992)

After assigning the particle info a pixel size from the first line of the parameters file, the issue was resolved, refinement could be run successfully:

![good_fsc](https://github.com/user-attachments/assets/12e2b66c-bfa2-49fa-ad89-3779d78a6c4e)


Fixes #523

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [x] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
