### PR TITLE
Blank edges now properly excluded when selected

### DIFF
--- a/src/programs/refine2d/refine2d.cpp
+++ b/src/programs/refine2d/refine2d.cpp
@@ -808,7 +808,7 @@ bool Refine2DApp::DoCalculation( ) {
                 }
                 //if (exclude_blank_edges && input_image_local.ContainsBlankEdges(mask_radius_for_noise)) {number_of_blank_edges_local++; continue;}
 
-                if ( input_image_local.ContainsBlankEdges(mask_radius_for_noise) || input_image_local.ContainsRepeatedLineEdges( ) ) {
+                if ( exclude_blank_edges && (input_image_local.ContainsBlankEdges(mask_radius_for_noise) || input_image_local.ContainsRepeatedLineEdges( )) ) {
                     number_of_blank_edges_local++;
                     continue;
                 }


### PR DESCRIPTION
# Description

When specifying to exclude blank images during 2D classification, the option wasn't properly specified in refine2d.cpp. The result was blank class averages despite the parameter being checked. Adding an additional bool flag to the check resolved the issue.

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [ ] core library
- [ ] gpu core library
- [x] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
