### PR TITLE
Purpose: fixes overly strict debug assert on parallel thread regions that are not safe

### DIFF
--- a/src/core/core_headers.h
+++ b/src/core/core_headers.h
@@ -70,6 +70,7 @@ typedef struct CurvePoint {
 #include <wx/wfstream.h>
 #include <wx/tokenzr.h>
 #include <wx/textfile.h>
+#include <wx/log.h>
 #include <wx/regex.h>
 #include <wx/stackwalk.h>
 #include <wx/xml/xml.h>
@@ -230,5 +231,13 @@ inline int ReturnNumberOfThreads( ) {
     return 1;
 #endif
 };
+
+inline bool ReturnInParallelRegionBool( ) {
+#ifdef _OPENMP
+    return omp_in_parallel( ) == 0 ? false : true;
+#else
+    return false;
+#endif
+}
 
 #endif // SRC_PROGRAMS_CORE_CORE_HEADERS_H_

--- a/src/core/defines.h
+++ b/src/core/defines.h
@@ -75,6 +75,7 @@ namespace cistem {
 #define MyPrintfRed(...)  {wxPrintf(ANSI_COLOR_RED); wxPrintf(__VA_ARGS__); wxPrintf(ANSI_COLOR_RESET);}
 
 #ifdef DEBUG
+#define MyDebugWarnThreadSafety(cond, ...) {if (cond) { wxLogWarning("Potential thread safety issue detected, this object should be declared private or explicitly constructed in thread parallel region %s:%i\n%s\n", __FILE__,__LINE__,__PRETTY_FUNCTION__); }}
 #define MyDebugPrintWithDetails(...)	{wxPrintf(__VA_ARGS__); wxPrintf("From %s:%i\n%s\n\n", __FILE__,__LINE__,__PRETTY_FUNCTION__); StackDump dump(NULL); dump.Walk(2);}
 #define MyPrintWithDetails(...)	{wxPrintf(__VA_ARGS__); wxPrintf("From %s:%i\n%s\n", __FILE__,__LINE__,__PRETTY_FUNCTION__);StackDump dump(NULL); dump.Walk(2);}
 #define MyDebugPrint(...)	{wxPrintf(__VA_ARGS__); wxPrintf("\n");}
@@ -82,6 +83,7 @@ namespace cistem {
 #define MyDebugAssertFalse(cond, msg, ...) {if ((cond) == true) { wxPrintf("\n" msg, ##__VA_ARGS__); wxPrintf("\nFailed Assert at %s:%i\n%s\n", __FILE__,__LINE__,__PRETTY_FUNCTION__); DEBUG_ABORT;}}
 #define DEBUG_ABORT {StackDump dump(NULL); dump.Walk(1); abort();}
 #else
+#define MyDebugWarnThreadSafety(cond, ...) 
 #define MyPrintWithDetails(...)	{wxPrintf(__VA_ARGS__); wxPrintf("From %s:%i\n%s\n", __FILE__,__LINE__,__PRETTY_FUNCTION__);}
 #define MyDebugPrintWithDetails(...)
 #define MyDebugPrint(...)

--- a/src/core/empirical_distribution.h
+++ b/src/core/empirical_distribution.h
@@ -16,6 +16,8 @@ class EmpiricalDistribution {
     bool          is_constant;
     float         last_added_value;
 
+    bool const constructed_in_parallel_region;
+
     Accumulator_t mean_welford;
     Accumulator_t var_times_n_minus_1_welford;
     // We don't trax min/max/last_added_value  or is_constant for Welford, set this to prevent those methods
@@ -26,7 +28,12 @@ class EmpiricalDistribution {
   public:
     // Constructors, destructors
     EmpiricalDistribution( );
+    EmpiricalDistribution(const EmpiricalDistribution& other);
+    EmpiricalDistribution(EmpiricalDistribution&& other) noexcept;
     ~EmpiricalDistribution( );
+
+    EmpiricalDistribution& operator=(const EmpiricalDistribution& other);
+    EmpiricalDistribution& operator=(EmpiricalDistribution&& other) noexcept;
 
     void  AddSampleValue(float sample_value);
     void  AddSampleValueWithKahanCorrection(float sample_value);
@@ -44,6 +51,9 @@ class EmpiricalDistribution {
     inline float GetMaximum( ) { return maximum; };
 
     bool IsConstant( );
+
+    inline bool GetConstructedInParallelRegion( ) const { return constructed_in_parallel_region; }
+
     void PopulateHistogram( );
     void Reset( );
 };


### PR DESCRIPTION
End goal: use wxLogMessage to instead print an annoying message if EmpiricalDistribution objects are called from a threaded region and they are declared outside that region.

Details: Change EmpiricalDistribution to check whether or not it is in a parallel region when constructed. Compare that const bool to the value returned on checking during function calls.

Test: the wxLogMessage can be captured and queried allowing for console test to work.

Files details:

core_headers.h
    - add a method to return bool if in parallel region when openMP is defined.
    - add header for access to wxLog functions

defines.h
    - add MyDebugWarnThreadSafety to carry out this logging/warning only in debug mode.

empirical_distribution.cpp/h
    - In addition to recording the state at construction in the existing constructor, add copy/move constructors that also set their own version of this bool on construction. This is needed when using, for example, omp private which will copy the variable and construct it inside the parallel regions.

console_test.cpp
    - adds a set of simple tests to make sure things work. I did not test this without openMP enabled, since we never compile that way, but in principle it should be fine with the include guards I added just to be safe.

# Description

Please include a summary of the change and which issue is fixed. Please also include **relevant motivation** and context. It is usually easy to see what you are doing, so please be thoughtful with explaining *Why* you are doing it!

Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [X] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [X] core library
- [ ] gpu core library
- [X] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested manually from GUI
- [X] Tested manually from CLI
- [X] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [meant too] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
