### PR TITLE
Fix a few oversights in new workflow switching.

### DIFF
--- a/.vscode_shared/CistemDev/workspace.code-workspace
+++ b/.vscode_shared/CistemDev/workspace.code-workspace
@@ -1,7 +1,7 @@
 {
     "folders": [
         {
-            "path": "/workspaces/CistemDev"
+            "path": "/workspaces/cisTEM"
         }
     ],
     "settings": {

--- a/.vscode_shared/CistemDev/workspace.code-workspace
+++ b/.vscode_shared/CistemDev/workspace.code-workspace
@@ -1,7 +1,7 @@
 {
     "folders": [
         {
-            "path": "../"
+            "path": "/workspaces/CistemDev"
         }
     ],
     "settings": {

--- a/regenerate_containers.sh
+++ b/regenerate_containers.sh
@@ -25,8 +25,8 @@ fi
 # somewhere near vscode 1.98 the devcontainers extension stopped recognizing softlinks to .devcontainer.json
 # this is acknowedged as a bug (https://github.com/microsoft/vscode-remote-release/issues/10536)
 # As a workaround we create a softlink to .devcontainer.json in the current directory
-mkdir -p .devcontainer.json
-cd  .devcontainer.json
+mkdir -p .devcontainer
+cd  .devcontainer
 if [[ ! -L .devcontainer.json ]] ; then
     ln -s ../.vscode/devcontainer.json .devcontainer.json
 fi

--- a/scripts/containers/top_image/Dockerfile
+++ b/scripts/containers/top_image/Dockerfile
@@ -65,8 +65,7 @@ RUN if [[ "x${build_type}" != "xstatic" ]]; then echo "export LD_RUN_PATH=/opt/l
 # RUN ls /usr/local/cuda/lib64/lib*_static.a | grep -v cufft_static.a | while read a; do rm -rf /usr/local/cuda/lib64/$(basename $a); done && \
 #     rm -rf /usr/local/cuda/lib64/libcufft_static_nocallback.a
 
-
+RUN echo "set filename-display basename" > /home/cisTEMdev/.gdbinit
 
 USER cisTEMdev
 WORKDIR /home/cisTEMdev
-

--- a/src/gui/MainFrame.h
+++ b/src/gui/MainFrame.h
@@ -102,8 +102,6 @@ class MyMainFrame : public MainFrame, public SocketCommunicator, public UpdatePr
     template <class FrameTypeFrom, class FrameTypeTo>
     void UpdateWorkflow(FrameTypeFrom* input_frame, FrameTypeTo* output_frame, wxString frame_name);
 
-    void SetSingleParticleWorkflow(bool triggered_by_gui_event = false);
-    void SetTemplateMatchingWorkflow(bool triggered_by_gui_event = false);
     void SwitchWorkflowPanels(const wxString& workflow_name);
 
     inline void ManuallyUpdateWorkflowMenuCheckBox( ) {

--- a/src/gui/workflows/SpaWorkflow.h
+++ b/src/gui/workflows/SpaWorkflow.h
@@ -63,7 +63,7 @@ struct SpaWorkflowRegister {
             actions_panel->ActionsBook->AddPage(generate_3d_panel, "Generate 3D", false, 8);
             actions_panel->ActionsBook->AddPage(sharpen_3d_panel, "Sharpen 3D", false, 9);
 
-            return actions_panel;
+                return actions_panel;
         };
         // TODO: define a results panel function as well
         WorkflowRegistry::Instance( ).RegisterWorkflow(def);

--- a/src/gui/workflows/TmWorkflow.h
+++ b/src/gui/workflows/TmWorkflow.h
@@ -35,7 +35,6 @@ struct TmWorkflowRegister {
             actions_panel                    = static_cast<ActionsPanelParent*>(actions_panel_tm);
             align_movies_panel               = new MyAlignMoviesPanel(actions_panel->ActionsBook);
             findctf_panel                    = new MyFindCTFPanel(actions_panel->ActionsBook);
-            match_template_results_panel     = new MatchTemplateResultsPanel(actions_panel->ActionsBook);
             match_template_panel             = new MatchTemplatePanel(actions_panel->ActionsBook);
             refine_template_panel            = new RefineTemplatePanel(actions_panel->ActionsBook);
             generate_3d_panel                = new Generate3DPanel(actions_panel->ActionsBook);
@@ -49,7 +48,6 @@ struct TmWorkflowRegister {
             actions_panel->ActionsBook->AddPage(findctf_panel, "Find CTF", false, 1);
             actions_panel->ActionsBook->AddPage(match_template_panel, "Match Templates", false, 2);
             actions_panel->ActionsBook->AddPage(refine_template_panel, "Refine Template", false, 3);
-            actions_panel->ActionsBook->AddPage(match_template_results_panel, "MT Results", false, 2);
             actions_panel->ActionsBook->AddPage(generate_3d_panel, "Generate 3D", false, 4);
             actions_panel->ActionsBook->AddPage(sharpen_3d_panel, "Sharpen 3D", false, 5);
 

--- a/src/programs/projectx/projectx.cpp
+++ b/src/programs/projectx/projectx.cpp
@@ -25,8 +25,8 @@ RefineCTFPanel*       refine_ctf_panel;
 Generate3DPanel*      generate_3d_panel;
 Sharpen3DPanel*       sharpen_3d_panel;
 
-MyOverviewPanel*    overview_panel;
-ActionsPanelParent* actions_panel;
+MyOverviewPanel*           overview_panel;
+ActionsPanelParent*        actions_panel;
 AssetsPanel*               assets_panel;
 MyResultsPanel*            results_panel;
 SettingsPanel*             settings_panel;
@@ -141,17 +141,18 @@ bool MyGuiApp::OnInit( ) {
 
     refinement_package_asset_panel = new MyRefinementPackageAssetPanel(assets_panel->AssetsBook);
 
-	// See src/gui/workflows/SpaWorkflow.h for instantiation of the SPA workflow panels
+    // See src/gui/workflows/SpaWorkflow.h for instantiation of the SPA workflow panels
 
     actions_panel = static_cast<ActionsPanelParent*>(WorkflowRegistry::Instance( ).CreateActionsPanel("Single Particle", main_frame->MenuBook));
 
-    movie_results_panel      = new MyMovieAlignResultsPanel(results_panel->ResultsBook);
-    ctf_results_panel        = new MyFindCTFResultsPanel(results_panel->ResultsBook);
-    picking_results_panel    = new MyPickingResultsPanel(results_panel->ResultsBook);
-    refine2d_results_panel   = new Refine2DResultsPanel(results_panel->ResultsBook);
-    refinement_results_panel = new MyRefinementResultsPanel(results_panel->ResultsBook);
+    movie_results_panel          = new MyMovieAlignResultsPanel(results_panel->ResultsBook);
+    ctf_results_panel            = new MyFindCTFResultsPanel(results_panel->ResultsBook);
+    picking_results_panel        = new MyPickingResultsPanel(results_panel->ResultsBook);
+    refine2d_results_panel       = new Refine2DResultsPanel(results_panel->ResultsBook);
+    refinement_results_panel     = new MyRefinementResultsPanel(results_panel->ResultsBook);
+    match_template_results_panel = new MatchTemplateResultsPanel(results_panel->ResultsBook);
 
-	// See src/gui/workflows/TmWorkflow.h for instantiation of Template Matching workflow panels.
+    // See src/gui/workflows/TmWorkflow.h for instantiation of Template Matching workflow panels.
 
 #ifdef EXPERIMENTAL
     refine_template_dev_panel = new RefineTemplateDevPanel(experimental_panel->ExperimentalBook);
@@ -230,7 +231,7 @@ bool MyGuiApp::OnInit( ) {
 
     SettingsBookIconImages->Add(run_profiles_icon_bmp);
 
-	// See src/gui/workflows headers for assignment of wxImageList to Actions Panel
+    // See src/gui/workflows headers for assignment of wxImageList to Actions Panel
     main_frame->MenuBook->AssignImageList(MenuBookIconImages);
     assets_panel->AssetsBook->AssignImageList(AssetsBookIconImages);
     results_panel->ResultsBook->AssignImageList(ResultsBookIconImages);
@@ -259,13 +260,14 @@ bool MyGuiApp::OnInit( ) {
     assets_panel->AssetsBook->AddPage(volume_asset_panel, "3D Volumes", false, 3);
     assets_panel->AssetsBook->AddPage(refinement_package_asset_panel, "Refine Pkgs.", false, 4);
     assets_panel->AssetsBook->AddPage(atomic_coordinates_asset_panel, "Atomic Coordinates", false, 5);
-    assets_panel->AssetsBook->AddPage(template_matches_package_asset_panel, "MT Pkgs.", false, 4);
+    assets_panel->AssetsBook->AddPage(template_matches_package_asset_panel, "TM Pkgs.", false, 4); // re-using icon FIXME
 
     results_panel->ResultsBook->AddPage(movie_results_panel, "Align Movies", true, 0);
     results_panel->ResultsBook->AddPage(ctf_results_panel, "Find CTF", false, 1);
     results_panel->ResultsBook->AddPage(picking_results_panel, "Find Particles", false, 2);
     results_panel->ResultsBook->AddPage(refine2d_results_panel, "2D Classify", false, 3);
     results_panel->ResultsBook->AddPage(refinement_results_panel, "3D Refinement", false, 4);
+    results_panel->ResultsBook->AddPage(match_template_results_panel, "TM Results", false, 2); // re-using icon FIXME
 
     settings_panel->SettingsBook->AddPage(run_profiles_panel, "Run Profiles", true, 0);
 


### PR DESCRIPTION
# General problem

See #546 

# Fixes

- Fixes state tracking by forcing refresh on TM switch
    - Opted to do this by calling DirtyEverthing in MainFrame switch workflow method 
       - Pros: centralized and easy
       - Cons: forces a refresh across the GUI, but performance not likely a problem given infrequency of swiching. 
       - Alternative: We could make all new panels dirty their own on construction if they have their main frame pointer

- When loading the project the DB select was still returning empty.
    - Added a warning and set default. - It would be better to figure out why this happens, but will see if there is observable behavior later
        
- When loading the project, the TM results are not being set because we default to SPA mode 
    - Move the TM results to the results panel and that fixes things.

- Remove stale methods to Set workflows in Mainframe.h

# Additional small changes for devcontainer debugging

- change workspace to full path (instead of code . , open with devcon…tainer open)

- Add this to the run container to ensure GDB prints clickable paths in the devcontainer
    - RUN echo "set filename-display basename" > /home/cisTEMdev/.gdbinit

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [X] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [X] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
