### PR TITLE
Make devcontainer flexible for git worktrees and remove SA specific mounts in devcontainer.json

### DIFF
--- a/.vscode_shared/CistemDev/devcontainer.json
+++ b/.vscode_shared/CistemDev/devcontainer.json
@@ -1,5 +1,7 @@
 {
-    "name": "cisTEMdev-wxSTABLE-static12",
+    "name": "cisTEM-${localEnv:USER}-${localWorkspaceFolderBasename}",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/cisTEM,type=bind,consistency=cached",
+    "workspaceFolder": "/workspaces/cisTEM",
     "image": "cistemdashorg/cistem_build_env:v2.2.2",
     "remoteUser": "cisTEMdev",
     "hostRequirements": {
@@ -38,13 +40,9 @@
             ]
         }
     }
-    // ,
-    // "mounts": [
-    //     "source=${localEnv:CISTEM_DEV_SCRATCH_DIR},target=/mnt,type=bind,consistency=cached"
-    // ]
-    ,
-    "mounts": [
-        "source=/scratch,target=/scratch,type=bind,consistency=cached",
-        "source=/sa_shared,target=/sa_shared,type=bind,consistency=cached"
-    ]
+    // For custom mounts, use devcontainer CLI with --mount flag instead of hardcoding here.
+    // Example bash aliases (add to ~/.bashrc):
+    //   alias cistem-devcontainer='devcontainer up --mount type=bind,source=/scratch,target=/scratch --mount type=bind,source=/sa_shared,target=/sa_shared && devcontainer open'
+    //   alias cistem-devcontainer-rebuild='devcontainer up --remove-existing-container --build-no-cache --mount type=bind,source=/scratch,target=/scratch --mount type=bind,source=/sa_shared,target=/sa_shared && devcontainer open'
+    // Usage: Run from workspace directory: cistem-devcontainer (or cistem-devcontainer-rebuild to force rebuild)
 }


### PR DESCRIPTION
## Summary
- Updates devcontainer.json to support git worktrees with dynamic container naming
- Removes hardcoded mount paths in favor of CLI-based configuration
- Maintains VS Code compatibility across main repo and worktrees

## Changes
- **Dynamic container naming**: `cisTEM-${USER}-${localWorkspaceFolderBasename}` provides descriptive names showing user and branch/worktree
- **Fixed workspace mount**: All worktrees mount at `/workspaces/cisTEM` to work with VS Code workspace configurations
- **Flexible mounts**: Removed hardcoded mounts from config; users add custom mounts via bash aliases using `devcontainer up --mount` flags

## Benefits
- Easy to identify which container belongs to which worktree/branch
- No need to modify committed config for user-specific mount paths
- Simple rebuild workflow with `--remove-existing-container` flag
- Works seamlessly with both main repo and worktrees

## Usage Example
See comments in devcontainer.json for bash alias examples:
```bash
alias cistem-devcontainer='devcontainer up --mount type=bind,source=/scratch,target=/scratch --mount type=bind,source=/sa_shared,target=/sa_shared && devcontainer open'
```