### PR TITLE
Feat: Added Export Particles Button

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -118,6 +118,7 @@ noinst_HEADERS = core/stopwatch.h \
                  gui/MySettingsPanel.h \
                  gui/PickingResultsPanel.h \
                  gui/MyParticlePositionExportDialog.h \
+                 gui/MyPickingJobExportDialog.h \
                  gui/MyFrealignExportDialog.h \
                  gui/MyRelionExportDialog.h \
                  gui/MyRefinementPackageAssetPanel.h \
@@ -722,6 +723,7 @@ cisTEM_SOURCES = programs/projectx/projectx.cpp \
                 gui/ActionsPanelTm.cpp \
                 gui/MySettingsPanel.cpp \
                 gui/MyParticlePositionExportDialog.cpp \
+                gui/MyPickingJobExportDialog.cpp \
                 gui/MyFrealignExportDialog.cpp \
                 gui/MyRelionExportDialog.cpp \
                 gui/MyRefinementPackageAssetPanel.cpp \

--- a/src/gui/MyParticlePositionAssetPanel.cpp
+++ b/src/gui/MyParticlePositionAssetPanel.cpp
@@ -1,5 +1,6 @@
 //#include "../core/core_headers.h"
 #include "../core/gui_core_headers.h"
+#include "MyPickingJobExportDialog.h"
 
 extern MyImageAssetPanel* image_asset_panel;
 
@@ -8,6 +9,7 @@ MyParticlePositionAssetPanel::MyParticlePositionAssetPanel(wxWindow* parent)
     RenameAssetButton->Show(false);
     DisplayButton->Show(false);
     DisplayButton->Enable(false);
+    ExportButton->Show(true);
     Layout( );
 
     Label0Title->SetLabel("");
@@ -354,7 +356,7 @@ void MyParticlePositionAssetPanel::NewFromParentClick(wxCommandEvent& event) {
 }
 
 void MyParticlePositionAssetPanel::ImportAssetClick(wxCommandEvent& event) {
-    // Get a text file which should have asset_id x_pos y_pos
+    // Get a text file which should have image_asset_id x_pos y_pos
 
     wxFileDialog openFileDialog(this, _("Open TXT file"), "", "", "TXT files (*.txt)|*.txt;*.txt", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
 
@@ -368,6 +370,18 @@ void MyParticlePositionAssetPanel::ImportAssetClick(wxCommandEvent& event) {
         input_file.Open(openFileDialog.GetPath( ));
         MyErrorDialog* my_error = new MyErrorDialog(this);
         long           image_asset_id;
+
+        // Create a new group named after the imported file (without extension)
+        wxString new_group_name = openFileDialog.GetFilename( ).BeforeLast('.');
+        if ( new_group_name.IsEmpty( ) )
+            new_group_name = openFileDialog.GetFilename( );
+        current_group_number++;
+        all_groups_list->AddGroup(new_group_name);
+        all_groups_list->groups[all_groups_list->number_of_groups - 1].id = current_group_number;
+        AddGroupToDatabase(current_group_number, new_group_name.ToUTF8( ).data( ), current_group_number);
+        long new_group_index = all_groups_list->number_of_groups - 1;
+
+        wxArrayLong imported_asset_indices;
 
         ParticlePositionAsset temp_asset;
         temp_asset.pick_job_id = -1;
@@ -387,7 +401,6 @@ void MyParticlePositionAssetPanel::ImportAssetClick(wxCommandEvent& event) {
 
             if ( current_line.IsEmpty( ) == false && current_line.StartsWith("#") == false ) {
                 current_tokenizer.SetString(current_line);
-                wxPrintf("Current Line = %s, number_tokens = %li\n", current_line, current_tokenizer.CountTokens( ));
 
                 if ( current_tokenizer.CountTokens( ) < 3 ) {
                     my_error->ErrorText->AppendText(wxString::Format(wxT("Line %li contains less than 3 (%li) values and will be ignored\n"), counter, current_tokenizer.CountTokens( )));
@@ -440,6 +453,11 @@ void MyParticlePositionAssetPanel::ImportAssetClick(wxCommandEvent& event) {
                                     AddAsset(&temp_asset);
                                     //main_frame->current_project.database.AddNextParticlePositionAsset(temp_asset.asset_id, temp_asset.parent_id, temp_asset.pick_job_id, temp_asset.x_position, temp_asset.y_position);
                                     main_frame->current_project.database.AddNextParticlePositionAsset(&temp_asset);
+
+                                    // Track this asset for the new group
+                                    long new_asset_index = all_assets_list->number_of_assets - 1;
+                                    all_groups_list->groups[new_group_index].AddMember(new_asset_index);
+                                    imported_asset_indices.Add(new_asset_index);
                                 }
                             }
                         }
@@ -452,9 +470,20 @@ void MyParticlePositionAssetPanel::ImportAssetClick(wxCommandEvent& event) {
 
         main_frame->current_project.database.EndParticlePositionAssetInsert( );
 
+        // Populate the new group in the database
+        if ( imported_asset_indices.GetCount( ) > 0 ) {
+            InsertArrayofGroupMembersToDatabase(new_group_index, &imported_asset_indices, NULL);
+        }
+        else {
+            // Nothing was imported; remove the empty group
+            all_groups_list->RemoveGroup(new_group_index);
+            RemoveGroupFromDatabase(current_group_number);
+            current_group_number--;
+        }
+
         my_dialog->Destroy( );
 
-        // errros?
+        // errors?
 
         if ( have_errors == true ) {
             my_error->ShowModal( );
@@ -462,6 +491,23 @@ void MyParticlePositionAssetPanel::ImportAssetClick(wxCommandEvent& event) {
 
         my_error->Destroy( );
 
+        FillGroupList( );
+        FillContentsList( );
+        DirtyGroups( );
+        main_frame->RecalculateAssetBrowser( );
+
         is_dirty = true;
     }
+}
+
+void MyParticlePositionAssetPanel::OnExportClick(wxCommandEvent& event) {
+    if ( ReturnNumberOfAssets( ) == 0 ) {
+        wxMessageBox(wxT("No particle positions to export."), wxT("Export"),
+                     wxOK | wxICON_INFORMATION, this);
+        return;
+    }
+
+    MyPickingJobExportDialog* dialog = new MyPickingJobExportDialog(this);
+    dialog->ShowModal( );
+    dialog->Destroy( );
 }

--- a/src/gui/MyParticlePositionAssetPanel.h
+++ b/src/gui/MyParticlePositionAssetPanel.h
@@ -9,6 +9,7 @@ class MyParticlePositionAssetPanel : public MyAssetPanelParent {
 
     void ImportAssetClick(wxCommandEvent& event);
     void NewFromParentClick(wxCommandEvent& event);
+    void OnExportClick(wxCommandEvent& event);
 
     void EnableNewFromParentButton( );
 

--- a/src/gui/MyPickingJobExportDialog.cpp
+++ b/src/gui/MyPickingJobExportDialog.cpp
@@ -1,0 +1,222 @@
+#include "../core/gui_core_headers.h"
+#include "MyPickingJobExportDialog.h"
+
+extern MyMainFrame*                  main_frame;
+extern MyImageAssetPanel*            image_asset_panel;
+extern MyParticlePositionAssetPanel* particle_position_asset_panel;
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+MyPickingJobExportDialog::MyPickingJobExportDialog(wxWindow* parent)
+    : wxDialog(parent, wxID_ANY, wxT("Export Particle Positions"),
+               wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE) {
+
+    wxBoxSizer* main_sizer = new wxBoxSizer(wxVERTICAL);
+
+    main_sizer->Add(new wxStaticText(this, wxID_ANY, wxT("Select export source:")),
+                    0, wxALL, 10);
+
+    JobComboBox = new wxComboBox(this, wxID_ANY, wxEmptyString,
+                                 wxDefaultPosition, wxSize(360, -1),
+                                 0, NULL, wxCB_READONLY);
+    main_sizer->Add(JobComboBox, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 10);
+
+    ParticleCountText = new wxStaticText(this, wxID_ANY, wxEmptyString);
+    main_sizer->Add(ParticleCountText, 0, wxLEFT | wxBOTTOM, 10);
+
+    main_sizer->Add(new wxStaticLine(this), 0, wxEXPAND | wxLEFT | wxRIGHT, 5);
+
+    wxBoxSizer* button_sizer = new wxBoxSizer(wxHORIZONTAL);
+    wxButton*   cancel_btn   = new wxButton(this, wxID_ANY, wxT("Cancel"));
+    wxButton*   export_btn   = new wxButton(this, wxID_ANY, wxT("Export..."));
+    button_sizer->Add(cancel_btn, 0, wxALL, 5);
+    button_sizer->Add(export_btn, 0, wxALL, 5);
+    main_sizer->Add(button_sizer, 0, wxALIGN_RIGHT | wxALL, 5);
+
+    SetSizer(main_sizer);
+    Fit( );
+    Centre( );
+
+    FillComboBox( );
+
+    JobComboBox->Bind(wxEVT_COMBOBOX, &MyPickingJobExportDialog::OnJobSelectionChange, this);
+    export_btn->Bind(wxEVT_BUTTON, &MyPickingJobExportDialog::OnExportButtonClick, this);
+    cancel_btn->Bind(wxEVT_BUTTON, &MyPickingJobExportDialog::OnCancelButtonClick, this);
+}
+
+// ---------------------------------------------------------------------------
+// Populate combo box
+// ---------------------------------------------------------------------------
+
+void MyPickingJobExportDialog::FillComboBox( ) {
+    entries_.clear( );
+    long total = particle_position_asset_panel->ReturnNumberOfAssets( );
+
+    // --- Section 1: job-based entries ---
+
+    // "All Jobs"
+    entries_.push_back({EntryType::AllJobs, 0, wxT("particles_all")});
+    JobComboBox->Append(wxString::Format(wxT("All Jobs (%ld particles)"), total));
+
+    // Collect unique pick_job_ids in order of first appearance
+    std::vector<int> seen_jobs;
+    for ( long i = 0; i < total; i++ ) {
+        int  jid   = particle_position_asset_panel->ReturnAssetPointer(i)->pick_job_id;
+        bool found = false;
+        for ( int v : seen_jobs )
+            if ( v == jid ) {
+                found = true;
+                break;
+            }
+        if ( ! found )
+            seen_jobs.push_back(jid);
+    }
+
+    for ( int jid : seen_jobs ) {
+        long count = CountForEntry({(jid == -1 ? EntryType::ManualPicks : EntryType::Job), jid, wxEmptyString});
+        if ( jid == -1 ) {
+            entries_.push_back({EntryType::ManualPicks, -1, wxT("particles_manual")});
+            JobComboBox->Append(wxString::Format(wxT("Manually picked (%ld particles)"), count));
+        }
+        else {
+            entries_.push_back({EntryType::Job, jid,
+                                wxString::Format(wxT("particles_job_%d"), jid)});
+            JobComboBox->Append(wxString::Format(wxT("Job #%d (%ld particles)"), jid, count));
+        }
+    }
+
+    // --- Section 2: user groups (groups 1+) ---
+
+    int num_groups = particle_position_asset_panel->ReturnNumberOfGroups( );
+    if ( num_groups > 1 ) {
+        // Dotted separator — stored as Separator entry, not selectable
+        entries_.push_back({EntryType::Separator, 0, wxEmptyString});
+        JobComboBox->Append(wxT("  -  -  -  -  -  -  -  -  -  -  -  -  -"));
+
+        for ( int g = 1; g < num_groups; g++ ) {
+            wxString gname = particle_position_asset_panel->ReturnGroupName(g);
+            long     count = particle_position_asset_panel->ReturnGroupSize(g);
+            entries_.push_back({EntryType::Group, g,
+                                wxT("particles_") + SanitizeFilename(gname)});
+            JobComboBox->Append(wxString::Format(wxT("%s (%ld particles)"), gname, count));
+        }
+    }
+
+    JobComboBox->SetSelection(0);
+    last_valid_selection_ = 0;
+    ParticleCountText->SetLabel(wxString::Format(wxT("%ld particles will be exported"), total));
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+long MyPickingJobExportDialog::CountForEntry(const ComboEntry& e) const {
+    long total = particle_position_asset_panel->ReturnNumberOfAssets( );
+    if ( e.type == EntryType::AllJobs )
+        return total;
+    if ( e.type == EntryType::Group )
+        return particle_position_asset_panel->ReturnGroupSize(e.value);
+    // Job or ManualPicks: count by pick_job_id
+    long count = 0;
+    for ( long i = 0; i < total; i++ )
+        if ( particle_position_asset_panel->ReturnAssetPointer(i)->pick_job_id == e.value )
+            count++;
+    return count;
+}
+
+wxString MyPickingJobExportDialog::SanitizeFilename(const wxString& name) const {
+    wxString result = name;
+    result.Replace(wxT(" "), wxT("_"));
+    result.Replace(wxT("/"), wxT("_"));
+    result.Replace(wxT("\\"), wxT("_"));
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+void MyPickingJobExportDialog::OnJobSelectionChange(wxCommandEvent& event) {
+    int sel = JobComboBox->GetSelection( );
+    if ( sel == wxNOT_FOUND )
+        return;
+
+    // Separator: snap back to last valid selection, do nothing
+    if ( entries_[sel].type == EntryType::Separator ) {
+        JobComboBox->SetSelection(last_valid_selection_);
+        return;
+    }
+
+    last_valid_selection_ = sel;
+    long count            = CountForEntry(entries_[sel]);
+    ParticleCountText->SetLabel(wxString::Format(wxT("%ld particles will be exported"), count));
+    Fit( );
+}
+
+void MyPickingJobExportDialog::OnExportButtonClick(wxCommandEvent& event) {
+    int sel = JobComboBox->GetSelection( );
+    if ( sel == wxNOT_FOUND )
+        return;
+    const ComboEntry& entry = entries_[sel];
+    if ( entry.type == EntryType::Separator )
+        return;
+
+    wxFileDialog save_dialog(this, wxT("Export particle positions"),
+                             wxEmptyString, entry.default_filename + wxT(".txt"),
+                             wxT("Text files (*.txt)|*.txt|All files (*.*)|*.*"),
+                             wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
+    if ( save_dialog.ShowModal( ) == wxID_CANCEL )
+        return;
+
+    wxFile output_file;
+    if ( ! output_file.Open(save_dialog.GetPath( ), wxFile::write) ) {
+        wxMessageBox(wxT("Could not open file for writing."), wxT("Export Error"),
+                     wxOK | wxICON_ERROR, this);
+        return;
+    }
+
+    //output_file.Write(wxT("# Image# X Y\n"));
+
+    if ( entry.type == EntryType::Group ) {
+        // Export members of a user-created group
+        int  g     = entry.value;
+        long gsize = particle_position_asset_panel->ReturnGroupSize(g);
+        for ( long m = 0; m < gsize; m++ ) {
+            long                   asset_idx = particle_position_asset_panel->ReturnGroupMember(g, m);
+            ParticlePositionAsset* asset     = particle_position_asset_panel->ReturnAssetPointer(asset_idx);
+            int                    image_pos = image_asset_panel->ReturnArrayPositionFromAssetID(asset->parent_id);
+            if ( image_pos < 0 )
+                continue;
+            ImageAsset* img   = image_asset_panel->ReturnAssetPointer(image_pos);
+            float       x_pix = float(asset->x_position) / img->pixel_size + 1.0f;
+            float       y_pix = float(img->y_size) - float(asset->y_position) / img->pixel_size + 1.0f;
+            output_file.Write(wxString::Format(wxT("%d %.2f %.2f\n"), asset->parent_id, x_pix, y_pix));
+        }
+    }
+    else {
+        // Export by pick_job_id (AllJobs, Job, or ManualPicks)
+        long total = particle_position_asset_panel->ReturnNumberOfAssets( );
+        for ( long i = 0; i < total; i++ ) {
+            ParticlePositionAsset* asset = particle_position_asset_panel->ReturnAssetPointer(i);
+            if ( entry.type != EntryType::AllJobs && asset->pick_job_id != entry.value )
+                continue;
+            int image_pos = image_asset_panel->ReturnArrayPositionFromAssetID(asset->parent_id);
+            if ( image_pos < 0 )
+                continue;
+            ImageAsset* img   = image_asset_panel->ReturnAssetPointer(image_pos);
+            float       x_pix = float(asset->x_position) / img->pixel_size + 1.0f;
+            float       y_pix = float(img->y_size) - float(asset->y_position) / img->pixel_size + 1.0f;
+            output_file.Write(wxString::Format(wxT("%d %.2f %.2f\n"), asset->parent_id, x_pix, y_pix));
+        }
+    }
+
+    output_file.Close( );
+    Close( );
+}
+
+void MyPickingJobExportDialog::OnCancelButtonClick(wxCommandEvent& event) {
+    Close( );
+}

--- a/src/gui/MyPickingJobExportDialog.h
+++ b/src/gui/MyPickingJobExportDialog.h
@@ -1,0 +1,42 @@
+#ifndef _SRC_GUI_MYPICKINGJOBEPORTDIALOG_H_
+#define _SRC_GUI_MYPICKINGJOBEPORTDIALOG_H_
+
+#include <vector>
+#include <wx/dialog.h>
+#include <wx/combobox.h>
+#include <wx/stattext.h>
+
+class MyPickingJobExportDialog : public wxDialog {
+  public:
+    MyPickingJobExportDialog(wxWindow* parent);
+
+    ~MyPickingJobExportDialog( ) {}
+
+  private:
+    enum class EntryType { AllJobs,
+                           Job,
+                           ManualPicks,
+                           Separator,
+                           Group };
+
+    struct ComboEntry {
+        EntryType type;
+        int       value; // pick_job_id for Job, group index for Group
+        wxString  default_filename; // pre-filled in the save dialog
+    };
+
+    wxComboBox*             JobComboBox;
+    wxStaticText*           ParticleCountText;
+    std::vector<ComboEntry> entries_;
+    int                     last_valid_selection_ = 0;
+
+    void     FillComboBox( );
+    long     CountForEntry(const ComboEntry& e) const;
+    wxString SanitizeFilename(const wxString& name) const;
+
+    void OnJobSelectionChange(wxCommandEvent& event);
+    void OnExportButtonClick(wxCommandEvent& event);
+    void OnCancelButtonClick(wxCommandEvent& event);
+};
+
+#endif

--- a/src/gui/ProjectX_gui_assets.cpp
+++ b/src/gui/ProjectX_gui_assets.cpp
@@ -1072,6 +1072,11 @@ AssetPanelParent::AssetPanelParent( wxWindow* parent, wxWindowID id, const wxPoi
 
 	bSizer28->Add( ResampleButton, 0, wxALL|wxEXPAND, 5 );
 
+	ExportButton = new wxButton( m_panel3, wxID_ANY, wxT("Export"), wxDefaultPosition, wxDefaultSize, 0 );
+	ExportButton->Hide();
+
+	bSizer28->Add( ExportButton, 0, wxALL|wxEXPAND, 5 );
+
 
 	bSizer25->Add( bSizer28, 0, wxEXPAND, 5 );
 
@@ -1260,6 +1265,7 @@ AssetPanelParent::AssetPanelParent( wxWindow* parent, wxWindowID id, const wxPoi
 	AddSelectedAssetButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::AddSelectedAssetClick ), NULL, this );
 	DisplayButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::OnDisplayButtonClick ), NULL, this );
 	ResampleButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::OnResampleClick ), NULL, this );
+	ExportButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::OnExportClick ), NULL, this );
 }
 
 AssetPanelParent::~AssetPanelParent()
@@ -1305,6 +1311,7 @@ AssetPanelParent::~AssetPanelParent()
 	AddSelectedAssetButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::AddSelectedAssetClick ), NULL, this );
 	DisplayButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::OnDisplayButtonClick ), NULL, this );
 	ResampleButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::OnResampleClick ), NULL, this );
+	ExportButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( AssetPanelParent::OnExportClick ), NULL, this );
 
 }
 

--- a/src/gui/ProjectX_gui_assets.cpp
+++ b/src/gui/ProjectX_gui_assets.cpp
@@ -1074,6 +1074,7 @@ AssetPanelParent::AssetPanelParent( wxWindow* parent, wxWindowID id, const wxPoi
 
 	ExportButton = new wxButton( m_panel3, wxID_ANY, wxT("Export"), wxDefaultPosition, wxDefaultSize, 0 );
 	ExportButton->Hide();
+	ExportButton->SetToolTip( wxT("Export particle positions to a text file") );
 
 	bSizer28->Add( ExportButton, 0, wxALL|wxEXPAND, 5 );
 

--- a/src/gui/ProjectX_gui_assets.h
+++ b/src/gui/ProjectX_gui_assets.h
@@ -344,6 +344,7 @@ class AssetPanelParent : public wxPanel
 		wxButton* AddSelectedAssetButton;
 		wxButton* DisplayButton;
 		wxButton* ResampleButton;
+		wxButton* ExportButton;
 		wxStaticLine* m_staticline6;
 		wxStaticText* Label0Title;
 		wxStaticText* Label0Text;
@@ -391,6 +392,7 @@ class AssetPanelParent : public wxPanel
 		virtual void AddSelectedAssetClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnDisplayButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnResampleClick( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnExportClick( wxCommandEvent& event ) { event.Skip(); }
 
 
 	public:

--- a/src/gui/wxformbuilder/ProjectX_assets.fbp
+++ b/src/gui/wxformbuilder/ProjectX_assets.fbp
@@ -8639,6 +8639,80 @@
                                                                     <event name="OnButtonClick">OnResampleClick</event>
                                                                 </object>
                                                             </object>
+                                                            <object class="sizeritem" expanded="0">
+                                                                <property name="border">5</property>
+                                                                <property name="flag">wxALL|wxEXPAND</property>
+                                                                <property name="proportion">0</property>
+                                                                <object class="wxButton" expanded="0">
+                                                                    <property name="BottomDockable">1</property>
+                                                                    <property name="LeftDockable">1</property>
+                                                                    <property name="RightDockable">1</property>
+                                                                    <property name="TopDockable">1</property>
+                                                                    <property name="aui_layer"></property>
+                                                                    <property name="aui_name"></property>
+                                                                    <property name="aui_position"></property>
+                                                                    <property name="aui_row"></property>
+                                                                    <property name="auth_needed">0</property>
+                                                                    <property name="best_size"></property>
+                                                                    <property name="bg"></property>
+                                                                    <property name="bitmap"></property>
+                                                                    <property name="caption"></property>
+                                                                    <property name="caption_visible">1</property>
+                                                                    <property name="center_pane">0</property>
+                                                                    <property name="close_button">1</property>
+                                                                    <property name="context_help"></property>
+                                                                    <property name="context_menu">1</property>
+                                                                    <property name="current"></property>
+                                                                    <property name="default">0</property>
+                                                                    <property name="default_pane">0</property>
+                                                                    <property name="disabled"></property>
+                                                                    <property name="dock">Dock</property>
+                                                                    <property name="dock_fixed">0</property>
+                                                                    <property name="docking">Left</property>
+                                                                    <property name="enabled">1</property>
+                                                                    <property name="fg"></property>
+                                                                    <property name="floatable">1</property>
+                                                                    <property name="focus"></property>
+                                                                    <property name="font"></property>
+                                                                    <property name="gripper">0</property>
+                                                                    <property name="hidden">1</property>
+                                                                    <property name="id">wxID_ANY</property>
+                                                                    <property name="label">Export</property>
+                                                                    <property name="margins"></property>
+                                                                    <property name="markup">0</property>
+                                                                    <property name="max_size"></property>
+                                                                    <property name="maximize_button">0</property>
+                                                                    <property name="maximum_size"></property>
+                                                                    <property name="min_size"></property>
+                                                                    <property name="minimize_button">0</property>
+                                                                    <property name="minimum_size"></property>
+                                                                    <property name="moveable">1</property>
+                                                                    <property name="name">ExportButton</property>
+                                                                    <property name="pane_border">1</property>
+                                                                    <property name="pane_position"></property>
+                                                                    <property name="pane_size"></property>
+                                                                    <property name="permission">protected</property>
+                                                                    <property name="pin_button">1</property>
+                                                                    <property name="pos"></property>
+                                                                    <property name="position"></property>
+                                                                    <property name="pressed"></property>
+                                                                    <property name="resize">Resizable</property>
+                                                                    <property name="show">1</property>
+                                                                    <property name="size"></property>
+                                                                    <property name="style"></property>
+                                                                    <property name="subclass">; ; forward_declare</property>
+                                                                    <property name="toolbar_pane">0</property>
+                                                                    <property name="tooltip">Export particle positions to a text file</property>
+                                                                    <property name="validator_data_type"></property>
+                                                                    <property name="validator_style">wxFILTER_NONE</property>
+                                                                    <property name="validator_type">wxDefaultValidator</property>
+                                                                    <property name="validator_variable"></property>
+                                                                    <property name="window_extra_style"></property>
+                                                                    <property name="window_name"></property>
+                                                                    <property name="window_style"></property>
+                                                                    <event name="OnButtonClick">OnExportClick</event>
+                                                                </object>
+                                                            </object>
                                                         </object>
                                                     </object>
                                                 </object>


### PR DESCRIPTION
# Description

Added Dialog box for Exporting Particle Picking Results by Job ID and if user created any custom groups. The filename to be saved gets auto poopulated to the Job ID or New Group name. Button is placed in Particle Picking Assets Panel. fixed Import Particles to create a new group by default once Particles are successfully imported.

## Summary

1. Added an **Export button** to the Particle Position Asset Panel that opens a job-scoped export dialog
2. Added **`MyPickingJobExportDialog`** — a new dialog for selecting which picking job or user group to export, with auto-populated default filenames
3. Fixed **Import** to create a new named group (derived from the filename) rather than adding all imported particles only to the "All Positions" group
4. Removed a stale **debug print** (`wxPrintf`) from the import path
5. Updated **wxFormBuilder `.fbp` files** to keep them in sync with all hand-edited generated code

## Details

1. **Export button moved to Asset Panel** — The Export button was originally prototyped on the per-image `PickingResultsDisplayPanel`, which meant a separate button appeared for every image in every job. This was the wrong level of granularity. The button is now on `AssetPanelParent` (hidden by default) and revealed only by `MyParticlePositionAssetPanel`, matching the scope at which particle positions are managed. The `.fbp` file (`ProjectX_assets.fbp`) was updated so future wxFormBuilder regeneration preserves the button.

2. **`MyPickingJobExportDialog`** — A hand-coded `wxDialog` (no fbp) that populates a `wxComboBox` with two visually separated sections:
   - *Above the dotted line*: unique `pick_job_id` values found in the assets table ("All Jobs", "Job #N", "Manually picked"), each showing particle count
   - *Below the dotted line* (only shown if user groups exist): named groups created by the user via Import or "New from image group"
   - The separator item is non-selectable; clicking it snaps back to the previous valid selection
   - The `wxFileDialog` is pre-populated with a sanitized default filename derived from the selection (e.g. `particles_job_3.txt`, `particles_My_Group.txt`)
   - Exported coordinates are converted from angstroms to 1-indexed pixel coordinates using the parent image's pixel size and Y dimension, matching the convention used by the existing `MyParticlePositionExportDialog`
   - Output format: space-separated `Image# X Y` with a `#`-prefixed header line so the Import parser skips it cleanly

3. **Import group creation fix** — Previously `ImportAssetClick` called `AddAsset()` for each parsed line, which only adds particles to group 0 ("All Positions"). After import there was no UI refresh, so the panel did not update until project reload. The fix:
   - Creates a new named group (name taken from the imported filename, without extension) before the parse loop, registering it in both `all_groups_list` and the database via `AddGroupToDatabase`
   - Accumulates newly added asset indices during the loop
   - After `EndParticlePositionAssetInsert`, batch-inserts group membership via `InsertArrayofGroupMembersToDatabase`
   - If no lines parsed successfully (all errors), cleans up the empty group
   - Calls `FillGroupList()`, `FillContentsList()`, `DirtyGroups()`, and `RecalculateAssetBrowser()` so the panel updates immediately without a project reload

4. **Debug print removed** — `wxPrintf("Current Line = %s, number_tokens = %li\n", ...)` was being called on every non-empty, non-comment line during import, producing verbose stdout output in production builds.

5. **Build system** — `MyPickingJobExportDialog.h` and `.cpp` added to `src/Makefile.am` alongside the other export dialog files.

# Related Issues/PRs

- Related to Manual Exporting of particles as explained in the Frequently Asked Questions. (Now automated).[#(issue number)](https://cistem.org/frequently-asked-questions)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [x] yes
- [ ] no

# Which compilers were tested

- [ ] g++
- [x] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [x] I have not changed anything that did not need to be changed
- [x] I have performed a self-review of my own code
- [x] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
